### PR TITLE
docs: 在 GHA 用户手册中新增 runner pod 资源配额说明

### DIFF
--- a/docs/user-manual-gha-en.md
+++ b/docs/user-manual-gha-en.md
@@ -13,6 +13,27 @@ Ascend clusters create runner pods to execute GitHub Action jobs. We offer the f
 |910B4|arm64|4|8|linux-aarch64-npu-x|
 |910B1|arm64|4|8|linux-aarch64-a2-x|
 
+### Runner Pod Resource Quota
+
+CPU and memory quota of each runner pod scales proportionally with the number of NPU chips requested:
+
+|Runner Name|NPU Chips|CPU (cores)|Memory|
+|--|--|--|--|
+|linux-aarch64-310p-1|1|11|40Gi|
+|linux-aarch64-310p-2|2|22|80Gi|
+|linux-aarch64-310p-4|4|44|160Gi|
+|linux-aarch64-910c-2|2|39|64Gi|
+|linux-aarch64-910c-4|4|78|128Gi|
+|linux-aarch64-910c-8|8|156|256Gi|
+|linux-aarch64-910c-16|16|312|512Gi|
+|linux-aarch64-npu-1|1|23|64Gi|
+|linux-aarch64-npu-2|2|46|128Gi|
+|linux-aarch64-npu-4|4|92|256Gi|
+|linux-aarch64-a2-1|1|23|64Gi|
+|linux-aarch64-a2-2|2|46|128Gi|
+|linux-aarch64-a2-4|4|92|256Gi|
+|linux-aarch64-a2-8|8|184|512Gi|
+
 ### Runner Naming Convention
 
 The naming convention for runner pod is composed of the following parts:

--- a/docs/user-manual-gha-en.md
+++ b/docs/user-manual-gha-en.md
@@ -10,7 +10,7 @@ Ascend clusters create runner pods to execute GitHub Action jobs. We offer the f
 |--|--|--|--|--|
 |310P3|arm64|1|8|linux-aarch64-310p-x|
 |910C|arm64|2|16|linux-aarch64-a3-x|
-|910B1|arm64|4|8|linux-aarch64-a2-x|
+|910B3|arm64|4|8|linux-aarch64-a2-x|
 |910B3|arm64|4|8|linux-aarch64-a2b3-x|
 
 ### Runner Pod Resource Quota

--- a/docs/user-manual-gha-en.md
+++ b/docs/user-manual-gha-en.md
@@ -6,12 +6,11 @@ We implement GitHub Action tasks on Ascend cluster nodes based on [ARC](https://
 
 Ascend clusters create runner pods to execute GitHub Action jobs. We offer the following types of Ascend chips. If no name is specified, the default naming will be applied.
 
-|Type|Architecture|Number of chips per Node|Default name(x = chip count)|
-|--|--|--|--|
-|310P3|arm64|8|linux-aarch64-310p-x|
-|A3|arm64|16|linux-aarch64-a3-x|
-|910B3|arm64|8|linux-aarch64-a2-x|
-|910B3|arm64|8|linux-aarch64-a2b3-x|
+|Type|Architecture|Default name(x = chip count)|
+|--|--|--|
+|Atlas 300I DUO|arm64|linux-aarch64-310p-x|
+|Atlas 800 A3|arm64|linux-aarch64-a3-x|
+|Atlas 800 A2|arm64|linux-aarch64-a2-x or linux-aarch64-a2b3-x|
 
 ### Runner Pod Resource Quota
 

--- a/docs/user-manual-gha-en.md
+++ b/docs/user-manual-gha-en.md
@@ -224,12 +224,12 @@ Note token expiration - after expiration, Runner scale set won't display in repo
 
 - PAT created and securely saved
 
-### Submit Activation Request
+### Submit Activation Request for Organization
 
 **What you need to do**:
 
 For token security, send email to `ascendinfra@huawei.com`.
-**Email subject**: `Request Ascend NPU Runners`
+**Email subject template**: `Request Ascend NPU Runners`
 **Email content template**:
 ```yaml
 org: my-org
@@ -267,12 +267,12 @@ Note token expiration - after expiration, Runner scale set won't display in repo
 
 - PAT created and securely saved
 
-### Submit Activation Request
+### Submit Activation Request for Repository
 
 **What you need to do**:
 
 For token security, send email to `ascendinfra@huawei.com`.
-**Email subject**: `Request Ascend NPU Runners`
+**Email subject template**: `Request Ascend NPU Runners`
 **Email content template**:
 ```yaml
 repo: https://github.com/my-org/my-repo

--- a/docs/user-manual-gha-en.md
+++ b/docs/user-manual-gha-en.md
@@ -6,12 +6,12 @@ We implement GitHub Action tasks on Ascend cluster nodes based on [ARC](https://
 
 Ascend clusters create runner pods to execute GitHub Action jobs. We offer the following types of Ascend chips. If no name is specified, the default naming will be applied.
 
-|Type|Architecture|Number of Nodes|Number of chips per Node|Default name(x = chip count)|
-|--|--|--|--|--|
-|310P3|arm64|1|8|linux-aarch64-310p-x|
-|910C|arm64|2|16|linux-aarch64-a3-x|
-|910B3|arm64|4|8|linux-aarch64-a2-x|
-|910B3|arm64|4|8|linux-aarch64-a2b3-x|
+|Type|Architecture|Number of chips per Node|Default name(x = chip count)|
+|--|--|--|--|
+|310P3|arm64|8|linux-aarch64-310p-x|
+|A3|arm64|16|linux-aarch64-a3-x|
+|910B3|arm64|8|linux-aarch64-a2-x|
+|910B3|arm64|8|linux-aarch64-a2b3-x|
 
 ### Runner Pod Resource Quota
 

--- a/docs/user-manual-gha-en.md
+++ b/docs/user-manual-gha-en.md
@@ -9,9 +9,9 @@ Ascend clusters create runner pods to execute GitHub Action jobs. We offer the f
 |Type|Architecture|Number of Nodes|Number of chips per Node|Default name(x = chip count)|
 |--|--|--|--|--|
 |310P3|arm64|1|8|linux-aarch64-310p-x|
-|910C|arm64|2|16|linux-aarch64-910c-x|
-|910B4|arm64|4|8|linux-aarch64-npu-x|
+|910C|arm64|2|16|linux-aarch64-a3-x|
 |910B1|arm64|4|8|linux-aarch64-a2-x|
+|910B3|arm64|4|8|linux-aarch64-a2b3-x|
 
 ### Runner Pod Resource Quota
 
@@ -22,27 +22,28 @@ CPU and memory quota of each runner pod scales proportionally with the number of
 |linux-aarch64-310p-1|1|11|40Gi|
 |linux-aarch64-310p-2|2|22|80Gi|
 |linux-aarch64-310p-4|4|44|160Gi|
-|linux-aarch64-910c-2|2|39|64Gi|
-|linux-aarch64-910c-4|4|78|128Gi|
-|linux-aarch64-910c-8|8|156|256Gi|
-|linux-aarch64-910c-16|16|312|512Gi|
-|linux-aarch64-npu-1|1|23|64Gi|
-|linux-aarch64-npu-2|2|46|128Gi|
-|linux-aarch64-npu-4|4|92|256Gi|
+|linux-aarch64-a3-2|2|39|64Gi|
+|linux-aarch64-a3-4|4|78|128Gi|
+|linux-aarch64-a3-8|8|156|256Gi|
+|linux-aarch64-a3-16|16|312|512Gi|
 |linux-aarch64-a2-1|1|23|64Gi|
 |linux-aarch64-a2-2|2|46|128Gi|
 |linux-aarch64-a2-4|4|92|256Gi|
 |linux-aarch64-a2-8|8|184|512Gi|
+|linux-aarch64-a2b3-1|1|23|64Gi|
+|linux-aarch64-a2b3-2|2|46|128Gi|
+|linux-aarch64-a2b3-4|4|92|256Gi|
+|linux-aarch64-a2b3-8|8|184|512Gi|
 
 ### Runner Naming Convention
 
 The naming convention for runner pod is composed of the following parts:
 
 ```
-linux-aarch64-npu-x
-^     ^       ^   ^
-|     |       |   |
-|     |       |   Number of NPUs Available
+linux-aarch64-a2-x
+^     ^       ^  ^
+|     |       |  |
+|     |       |  Number of NPUs Available
 |     |       NPU Designator
 |     Architecture
 Operating System
@@ -318,7 +319,7 @@ on:
   workflow_dispatch:
 jobs:
   job_0:
-    runs-on: linux-arm64-npu-1
+    runs-on: linux-aarch64-a2-1
     container:
       image: ascendai/cann:latest
       

--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -14,6 +14,27 @@
 |910B4|arm64|4|8|linux-aarch64-npu-x|
 |910B1|arm64|4|8|linux-aarch64-a2-x|
 
+### Runner pod 资源配额
+
+每个 runner pod 的 CPU 和内存配额按申请的 NPU 卡数等比例分配，具体如下：
+
+|Runner 名称|NPU 卡数|CPU(核)|内存|
+|--|--|--|--|
+|linux-aarch64-310p-1|1|11|40Gi|
+|linux-aarch64-310p-2|2|22|80Gi|
+|linux-aarch64-310p-4|4|44|160Gi|
+|linux-aarch64-910c-2|2|39|64Gi|
+|linux-aarch64-910c-4|4|78|128Gi|
+|linux-aarch64-910c-8|8|156|256Gi|
+|linux-aarch64-910c-16|16|312|512Gi|
+|linux-aarch64-npu-1|1|23|64Gi|
+|linux-aarch64-npu-2|2|46|128Gi|
+|linux-aarch64-npu-4|4|92|256Gi|
+|linux-aarch64-a2-1|1|23|64Gi|
+|linux-aarch64-a2-2|2|46|128Gi|
+|linux-aarch64-a2-4|4|92|256Gi|
+|linux-aarch64-a2-8|8|184|512Gi|
+
 ### 默认 runner pod 命名规范
 
 Runner pod 名称由以下部分组成：

--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -36,7 +36,7 @@
 |linux-aarch64-a2b3-4|4|92|256Gi|
 |linux-aarch64-a2b3-8|8|184|512Gi|
 
-### 默认 runner pod 命名规范
+### Runner pod 命名规范
 
 Runner pod 名称由以下部分组成：
 
@@ -114,7 +114,7 @@ Operating System
 
 ## 安装
 
-我们按照安装范围(组织/仓库)和接入权限(GitHub App/PAT)分别介绍安装方式。您可以选择其中一种种方式安装，也可以搭配多种方式混合安装。
+我们按照安装范围(组织/仓库)和接入权限(GitHub App/PAT)分别介绍安装方式。您可以选择其中一种方式安装，也可以搭配多种方式混合安装。
 如果安装到组织，可以在仓库间复用 runner。并且可以通过 runner group 限制仓库范围。如果安装到仓库，只有单个仓库可以使用 runner。
 GitHub App 权限更安全，但是需要组织管理者权限。如果觉得很难获取组织层面的许可，可以选择 PAT 权限。
 如果您在安装/使用过程中有任何问题，请[提出discussion](https://github.com/ascend-gha-runners/docs/discussions)。
@@ -146,7 +146,7 @@ runner group 有3个配置选项以控制仓库的 workflow 是否可以使用 r
 2. 仓库访问权限： private。
 3. workflow: 选择所有 workflow。
 
-您可以使用并更改默认 runner group 来管理 runner，跳过[新建 runner group](#新建-runner-group)。
+您可以使用并更改默认 runner group 来管理 runner。
 如果默认 runner group 已经管理 runner 并且其权限与新 runner 不同，您可以参考[新建 runner group](https://docs.github.com/en/actions/how-tos/hosting-your-own-runners/managing-self-hosted-runners/managing-access-to-self-hosted-runners-using-groups#creating-a-self-hosted-runner-group-for-an-organization)创建自定义 runner group 来管理 runner。
 
 ### 安装 GitHub App
@@ -231,8 +231,8 @@ scopes 选择`admin:org`。
 **你需要做什么**：
 
 考虑到token保密需求，申请方式是向`ascendinfra@huawei.com`发送邮件。
-邮件主题模板：`Request Ascend NPU Runners`
-邮件内容模板：
+**邮件主题模板**：`Request Ascend NPU Runners`
+**邮件内容模板**：
 ```yaml
 org: my-org
 token: ghp_xxx
@@ -274,8 +274,8 @@ scopes 选择`repo`。
 **你需要做什么**：
 
 考虑到token保密需求，申请方式是向`ascendinfra@huawei.com`发送邮件。
-邮件主题模板：`Request Ascend NPU Runners`
-邮件内容模板：
+**邮件主题模板**：`Request Ascend NPU Runners`
+**邮件内容模板**：
 ```yaml
 repo: https://github.com/my-org/my-repo
 token: ghp_xxx
@@ -308,7 +308,7 @@ expire-at: 30days
 
 - Runner 状态显示为 **Online**（绿色圆点）
 
-### 在workflow中使用NPU Runners
+### 在 workflow 中使用 NPU Runners
 
 **你需要做什么**：
 

--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -7,12 +7,11 @@
 昇腾集群创建 runner pod 执行 Github Action job。
 我们提供如下类型的昇腾芯片。如果您未指定名称，我们将使用默认命名。
 
-|类型|架构|每台节点卡数|默认命名(x表示卡数)|
-|--|--|--|--|
-|310P3|arm64|8|linux-aarch64-310p-x|
-|A3|arm64|16|linux-aarch64-a3-x|
-|910B3|arm64|8|linux-aarch64-a2-x|
-|910B3|arm64|8|linux-aarch64-a2b3-x|
+|类型|架构|默认命名(x表示卡数)|
+|--|--|--|
+|Atlas 300I DUO|arm64|linux-aarch64-310p-x|
+|Atlas 800 A3|arm64|linux-aarch64-a3-x|
+|Atlas 800 A2|arm64|linux-aarch64-a2-x 或 linux-aarch64-a2b3-x|
 
 ### Runner pod 资源配额
 

--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -7,12 +7,12 @@
 昇腾集群创建 runner pod 执行 Github Action job。
 我们提供如下类型的昇腾芯片。如果您未指定名称，我们将使用默认命名。
 
-|类型|架构|节点数|每台节点卡数|默认命名(x表示卡数)|
-|--|--|--|--|--|
-|310P3|arm64|1|8|linux-aarch64-310p-x|
-|910C|arm64|2|16|linux-aarch64-a3-x|
-|910B3|arm64|4|8|linux-aarch64-a2-x|
-|910B3|arm64|4|8|linux-aarch64-a2b3-x|
+|类型|架构|每台节点卡数|默认命名(x表示卡数)|
+|--|--|--|--|
+|310P3|arm64|8|linux-aarch64-310p-x|
+|A3|arm64|16|linux-aarch64-a3-x|
+|910B3|arm64|8|linux-aarch64-a2-x|
+|910B3|arm64|8|linux-aarch64-a2b3-x|
 
 ### Runner pod 资源配额
 

--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -10,9 +10,9 @@
 |类型|架构|节点数|每台节点卡数|默认命名(x表示卡数)|
 |--|--|--|--|--|
 |310P3|arm64|1|8|linux-aarch64-310p-x|
-|910C|arm64|2|16|linux-aarch64-910c-x|
-|910B4|arm64|4|8|linux-aarch64-npu-x|
+|910C|arm64|2|16|linux-aarch64-a3-x|
 |910B1|arm64|4|8|linux-aarch64-a2-x|
+|910B3|arm64|4|8|linux-aarch64-a2b3-x|
 
 ### Runner pod 资源配额
 
@@ -23,27 +23,28 @@
 |linux-aarch64-310p-1|1|11|40Gi|
 |linux-aarch64-310p-2|2|22|80Gi|
 |linux-aarch64-310p-4|4|44|160Gi|
-|linux-aarch64-910c-2|2|39|64Gi|
-|linux-aarch64-910c-4|4|78|128Gi|
-|linux-aarch64-910c-8|8|156|256Gi|
-|linux-aarch64-910c-16|16|312|512Gi|
-|linux-aarch64-npu-1|1|23|64Gi|
-|linux-aarch64-npu-2|2|46|128Gi|
-|linux-aarch64-npu-4|4|92|256Gi|
+|linux-aarch64-a3-2|2|39|64Gi|
+|linux-aarch64-a3-4|4|78|128Gi|
+|linux-aarch64-a3-8|8|156|256Gi|
+|linux-aarch64-a3-16|16|312|512Gi|
 |linux-aarch64-a2-1|1|23|64Gi|
 |linux-aarch64-a2-2|2|46|128Gi|
 |linux-aarch64-a2-4|4|92|256Gi|
 |linux-aarch64-a2-8|8|184|512Gi|
+|linux-aarch64-a2b3-1|1|23|64Gi|
+|linux-aarch64-a2b3-2|2|46|128Gi|
+|linux-aarch64-a2b3-4|4|92|256Gi|
+|linux-aarch64-a2b3-8|8|184|512Gi|
 
 ### 默认 runner pod 命名规范
 
 Runner pod 名称由以下部分组成：
 
 ```
-linux-aarch64-npu-x
-^     ^       ^   ^
-|     |       |   |
-|     |       |   Number of NPUs Available
+linux-aarch64-a2-x
+^     ^       ^  ^
+|     |       |  |
+|     |       |  Number of NPUs Available
 |     |       NPU Designator
 |     Architecture
 Operating System
@@ -320,7 +321,7 @@ on:
   workflow_dispatch:
 jobs:
   job_0:
-    runs-on: linux-arm64-npu-1
+    runs-on: linux-aarch64-a2-1
     container:
       image: ascendai/cann:latest
       

--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -11,7 +11,7 @@
 |--|--|--|--|--|
 |310P3|arm64|1|8|linux-aarch64-310p-x|
 |910C|arm64|2|16|linux-aarch64-a3-x|
-|910B1|arm64|4|8|linux-aarch64-a2-x|
+|910B3|arm64|4|8|linux-aarch64-a2-x|
 |910B3|arm64|4|8|linux-aarch64-a2b3-x|
 
 ### Runner pod 资源配额


### PR DESCRIPTION
## Summary
- 在 `docs/user-manual-gha-zh.md` 和 `docs/user-manual-gha-en.md` 的 Runner Pod 类型表格下方新增"Runner pod 资源配额"小节
- 列出 14 种 runner（310p / 910c / npu / a2 系列）的 CPU 核数和内存大小，便于用户根据资源规划 workflow
- 数据来源：ascend-ci-deployment 项目中各 runner 的 pod-template configmap

## Test plan
- [ ] 检查中英文文档中表格渲染正确
- [ ] 确认资源配额数据与 ascend-ci-deployment 中实际部署的 configmap 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)