### PR TITLE
ci: 缓存审计完整改进 — 自动更新 Repo.md

### DIFF
--- a/.github/workflows/check-cache-audit.yml
+++ b/.github/workflows/check-cache-audit.yml
@@ -15,7 +15,7 @@ jobs:
       GH_TOKEN: ${{ secrets.CACHE_AUDIT_TOKEN }}
       PYPI_CACHE_HOST: ${{ vars.PYPI_CACHE_HOST || 'cache-service.nginx-pypi-cache.svc.cluster.local' }}
       APT_CACHE_PORT: ${{ vars.APT_CACHE_PORT || '8081' }}
-      RUNNER_FILTER: ${{ vars.RUNNER_FILTER || 'linux-aarch64,self-hosted' }}
+      RUNNER_FILTER: ${{ vars.RUNNER_FILTER || 'linux-aarch64,linux-amd64' }}
       MAX_NPU_SEARCH: ${{ vars.MAX_NPU_SEARCH || '50' }}
 
     steps:
@@ -24,10 +24,31 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y jq
 
+      - name: Generate repos list from Repo.md
+        run: |
+          # 从 Repo.md 提取所有 org/repo
+          REPOS=$(grep -oE '\[([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)\]\(https://github\.com/' docs/Repo.md \
+            | grep -oE '[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+')
+
+          # repos.txt 作为 workflow 文件映射（格式：org/repo|workflow-file.yml）
+          # 有映射的用指定 workflow 文件，没有映射的用自动搜索模式
+          > /tmp/audit_repos.txt
+          while IFS= read -r REPO; do
+            MAPPING=$(grep "^${REPO}|" scripts/ci-audit/repos.txt 2>/dev/null || true)
+            if [ -n "$MAPPING" ]; then
+              echo "$MAPPING" >> /tmp/audit_repos.txt
+            else
+              echo "$REPO" >> /tmp/audit_repos.txt
+            fi
+          done <<< "$REPOS"
+
+          echo "=== 本次审计仓库列表 ==="
+          cat /tmp/audit_repos.txt
+
       - name: Run log-based cache audit
         id: audit
         run: |
-          bash scripts/ci-audit/check_cache_from_logs.sh scripts/ci-audit/repos.txt | tee audit_result.md
+          bash scripts/ci-audit/check_cache_from_logs.sh /tmp/audit_repos.txt | tee audit_result.md
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/check-cache-audit.yml
+++ b/.github/workflows/check-cache-audit.yml
@@ -3,10 +3,10 @@ name: CI Cache Audit
 on:
   schedule:
     - cron: "24 2 * * *" # 每天 10:24 北京时间 (UTC+8)
-  workflow_dispatch: # 支持手动触发
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   audit:
@@ -20,18 +20,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CACHE_AUDIT_TOKEN }}
 
       - name: Install dependencies
         run: sudo apt-get install -y jq
 
       - name: Generate repos list from Repo.md
         run: |
-          # 从 Repo.md 提取所有 org/repo
           REPOS=$(grep -oE '\[([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)\]\(https://github\.com/' docs/Repo.md \
             | grep -oE '[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+')
 
-          # repos.txt 作为 workflow 文件映射（格式：org/repo|workflow-file.yml）
-          # 有映射的用指定 workflow 文件，没有映射的用自动搜索模式
           > /tmp/audit_repos.txt
           while IFS= read -r REPO; do
             MAPPING=$(grep "^${REPO}|" scripts/ci-audit/repos.txt 2>/dev/null || true)
@@ -49,6 +48,25 @@ jobs:
         id: audit
         run: |
           bash scripts/ci-audit/check_cache_from_logs.sh /tmp/audit_repos.txt | tee audit_result.md
+
+      - name: Update Repo.md with audit results
+        run: |
+          python3 scripts/ci-audit/update_repo_md.py \
+            audit_result.md \
+            scripts/ci-audit/repos.txt \
+            docs/Repo.md
+
+      - name: Commit updated Repo.md
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/Repo.md
+          if git diff --cached --quiet; then
+            echo "No changes to Repo.md"
+          else
+            git commit -m "docs: update cache audit status in Repo.md [skip ci]"
+            git push
+          fi
 
       - name: Write job summary
         if: always()

--- a/docs/Repo.md
+++ b/docs/Repo.md
@@ -1,23 +1,21 @@
+# Integrated Repositories
+
 `NPU runners` have been integrated into the following repositories:
 
-[vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend)
+<!-- CACHE_AUDIT_TABLE_START -->
+| Repository | PyPI Cache | APT Cache | Last Checked |
+| :--- | :---: | :---: | :--- |
+| [vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend) | ✅ | ✅ | 2026-06-04 |
+| [vllm-project/vllm-omni](https://github.com/vllm-project/vllm-omni) | ✅ | ✅ | 2026-06-04 |
+| [Ascend/Ascend-CI](https://github.com/Ascend/Ascend-CI) | ❌ | ❌ | 2026-06-04 |
+| [pytorch-fdn/accelerator-integration-wg](https://github.com/pytorch-fdn/accelerator-integration-wg) | - | - | 2026-06-04 |
+| [sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu) | ❌ | ✅ | 2026-06-04 |
+| [sgl-project/sglang](https://github.com/sgl-project/sglang) | ✅ | ✅ | 2026-06-04 |
+| [volcengine/verl](https://github.com/volcengine/verl) | ✅ | ✅ | 2026-06-04 |
+| [hiyouga/LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) | ✅ | ✅ | 2026-06-04 |
+| [modelscope/ms-swift](https://github.com/modelscope/ms-swift) | ❌ | ✅ | 2026-06-04 |
+| [tile-ai/tilelang-ascend](https://github.com/tile-ai/tilelang-ascend) | ✅ | ✅ | 2026-06-04 |
+| [triton-lang/triton-ascend](https://github.com/triton-lang/triton-ascend) | ❌ | - | 2026-06-04 |
+<!-- CACHE_AUDIT_TABLE_END -->
 
-[vllm-project/vllm-omni](https://github.com/vllm-project/vllm-omni)
-
-[Ascend/Ascend-CI](https://github.com/Ascend/Ascend-CI)
-
-[pytorch-fdn/accelerator-integration-wg](https://github.com/pytorch-fdn/accelerator-integration-wg)
-
-[sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu)
-
-[sgl-project/sglang](https://github.com/sgl-project/sglang)
-
-[volcengine/verl](https://github.com/volcengine/verl)
-
-[hiyouga/LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory)
-
-[modelscope/ms-swift](https://github.com/modelscope/ms-swift)
-
-[tile-ai/tilelang-ascend](https://github.com/tile-ai/tilelang-ascend)
-
-[triton-lang/triton-ascend](https://github.com/triton-lang/triton-ascend)
+> Cache audit runs daily. ✅ = confirmed in use · ❌ = confirmed NOT in use · - = unknown

--- a/scripts/ci-audit/check_cache_from_logs.sh
+++ b/scripts/ci-audit/check_cache_from_logs.sh
@@ -42,7 +42,7 @@ fi
 PYPI_CACHE_HOST="${PYPI_CACHE_HOST:-cache-service.nginx-pypi-cache.svc.cluster.local}"
 APT_CACHE_PORT="${APT_CACHE_PORT:-8081}"
 APT_CACHE_HOST="${APT_CACHE_HOST:-}"
-RUNNER_FILTER="${RUNNER_FILTER:-linux-aarch64,self-hosted}"
+RUNNER_FILTER="${RUNNER_FILTER:-linux-aarch64,linux-amd64}"
 MAX_NPU_SEARCH="${MAX_NPU_SEARCH:-100}"
 PER_PAGE="${PER_PAGE:-30}"
 

--- a/scripts/ci-audit/check_cache_from_logs.sh
+++ b/scripts/ci-audit/check_cache_from_logs.sh
@@ -198,7 +198,7 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
 
         # Pre-check: skip jobs with no package installation activity at all
         # (e.g. docs-check, lint-only jobs that use pre-built images)
-        if ! grep -qiE "pip install|pip config|apt-get|apt install|uv install|uv pip|dnf install|yum install|rustup|cargo" "$log_file" 2>/dev/null; then
+        if ! grep -qiE "pip install|apt-get install|apt install|uv install|uv pip|dnf install|yum install|rustup toolchain|cargo install" "$log_file" 2>/dev/null; then
             rm -f "$log_file"
             continue
         fi

--- a/scripts/ci-audit/check_cache_from_logs.sh
+++ b/scripts/ci-audit/check_cache_from_logs.sh
@@ -102,10 +102,16 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
 
     while [ "$page" -le "$max_pages" ]; do
         if [ -n "$WORKFLOW_FILTER" ]; then
-            runs_json=$(gh api "repos/$REPO/actions/workflows/${WORKFLOW_FILTER}/runs?per_page=$PER_PAGE&page=$page" 2>/dev/null) || true
+            runs_success=$(gh api "repos/$REPO/actions/workflows/${WORKFLOW_FILTER}/runs?per_page=$PER_PAGE&page=$page&status=success" 2>/dev/null) || true
+            runs_failure=$(gh api "repos/$REPO/actions/workflows/${WORKFLOW_FILTER}/runs?per_page=$PER_PAGE&page=$page&status=failure" 2>/dev/null) || true
         else
-            runs_json=$(gh api "repos/$REPO/actions/runs?per_page=$PER_PAGE&page=$page" 2>/dev/null) || true
+            runs_success=$(gh api "repos/$REPO/actions/runs?per_page=$PER_PAGE&page=$page&status=success" 2>/dev/null) || true
+            runs_failure=$(gh api "repos/$REPO/actions/runs?per_page=$PER_PAGE&page=$page&status=failure" 2>/dev/null) || true
         fi
+        # 合并两次结果，按 run id 降序排列（新的优先）
+        runs_json=$(echo "${runs_success}${runs_failure}" | jq -sc '
+            {workflow_runs: ([.[].workflow_runs] | add // [] | sort_by(-.id))}
+        ' 2>/dev/null) || true
 
         if [ -z "$runs_json" ]; then
             break

--- a/scripts/ci-audit/check_cache_from_logs.sh
+++ b/scripts/ci-audit/check_cache_from_logs.sh
@@ -100,7 +100,7 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
     page=1
     max_pages=$(( (max_runs + PER_PAGE - 1) / PER_PAGE ))
 
-    while [ "$page" -le "$max_pages" ] && [ "$npu_found" = false ]; do
+    while [ "$page" -le "$max_pages" ]; do
         if [ -n "$WORKFLOW_FILTER" ]; then
             # Targeted: search only runs of the specified workflow
             runs_json=$(gh api "repos/$REPO/actions/workflows/${WORKFLOW_FILTER}/runs?per_page=$PER_PAGE&page=$page&status=completed" 2>/dev/null) || true

--- a/scripts/ci-audit/check_cache_from_logs.sh
+++ b/scripts/ci-audit/check_cache_from_logs.sh
@@ -102,11 +102,9 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
 
     while [ "$page" -le "$max_pages" ]; do
         if [ -n "$WORKFLOW_FILTER" ]; then
-            # Targeted: search only runs of the specified workflow
-            runs_json=$(gh api "repos/$REPO/actions/workflows/${WORKFLOW_FILTER}/runs?per_page=$PER_PAGE&page=$page&status=completed" 2>/dev/null) || true
+            runs_json=$(gh api "repos/$REPO/actions/workflows/${WORKFLOW_FILTER}/runs?per_page=$PER_PAGE&page=$page" 2>/dev/null) || true
         else
-            # Auto: search all completed runs
-            runs_json=$(gh api "repos/$REPO/actions/runs?per_page=$PER_PAGE&page=$page&status=completed" 2>/dev/null) || true
+            runs_json=$(gh api "repos/$REPO/actions/runs?per_page=$PER_PAGE&page=$page" 2>/dev/null) || true
         fi
 
         if [ -z "$runs_json" ]; then
@@ -134,7 +132,11 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
 
             filtered=$(echo "$jobs_json" | jq -r "
                 .jobs[]
-                | select(.labels | any(test(\"$RUNNER_REGEX\")))
+                | select(
+                    (.labels | any(test(\"$RUNNER_REGEX\"))) and
+                    .conclusion != \"skipped\" and
+                    .status == \"completed\"
+                )
                 | [\"$run_id\", \"$run_branch\", \"$run_name\", .id, .name, (.labels | join(\",\"))] | join(\"|\")
             " 2>/dev/null) || true
 

--- a/scripts/ci-audit/repos.txt
+++ b/scripts/ci-audit/repos.txt
@@ -1,6 +1,6 @@
-sgl-project/sglang
-vllm-project/vllm-ascend
-modelscope/ms-swift
-verl-project/verl
-hiyouga/LlamaFactory
-tile-ai/tilelang-ascend
+sgl-project/sglang|pr-test-npu.yml
+vllm-project/vllm-ascend|schedule_nightly_test_a2.yaml
+modelscope/ms-swift|citest_npu.yaml
+verl-project/verl|e2e_ascend.yml
+hiyouga/LlamaFactory|tests_npu.yml
+tile-ai/tilelang-ascend|ci_npuir.yml

--- a/scripts/ci-audit/repos.txt
+++ b/scripts/ci-audit/repos.txt
@@ -1,5 +1,5 @@
 sgl-project/sglang|pr-test-npu.yml
-vllm-project/vllm-ascend|schedule_nightly_test_a2.yaml
+vllm-project/vllm-ascend|pr_test_full.yaml
 modelscope/ms-swift|citest_npu.yaml
 verl-project/verl|e2e_ascend.yml
 hiyouga/LlamaFactory|tests_npu.yml

--- a/scripts/ci-audit/repos.txt
+++ b/scripts/ci-audit/repos.txt
@@ -1,8 +1,14 @@
-# workflow 文件映射（格式：org/repo|workflow-file.yml）
-# 未在此列出的仓库会自动搜索所有 run
-sgl-project/sglang|pr-test-npu.yml
-vllm-project/vllm-ascend|pr_test_full.yaml
-modelscope/ms-swift|citest_npu.yaml
-verl-project/verl|e2e_ascend.yml
-hiyouga/LlamaFactory|tests_npu.yml
-tile-ai/tilelang-ascend|ci_npuir.yml
+# org/repo|workflow-file.yml|pypi_default|apt_default
+# 默认值仅在审计无法确认时使用（⚙️/🔍/⚠️）
+# 审计确认的 ✅ 或 ❌ 优先级高于默认值
+sgl-project/sglang|pr-test-npu.yml||
+vllm-project/vllm-ascend|pr_test_full.yaml|✅|✅
+vllm-project/vllm-omni||✅|✅
+Ascend/Ascend-CI||||
+pytorch-fdn/accelerator-integration-wg||||
+sgl-project/sgl-kernel-npu||✅|✅
+volcengine/verl|e2e_ascend.yml|✅|✅
+hiyouga/LLaMA-Factory|tests_npu.yml||
+modelscope/ms-swift|citest_npu.yaml||
+tile-ai/tilelang-ascend|ci_npuir.yml||
+triton-lang/triton-ascend||||

--- a/scripts/ci-audit/repos.txt
+++ b/scripts/ci-audit/repos.txt
@@ -1,3 +1,5 @@
+# workflow 文件映射（格式：org/repo|workflow-file.yml）
+# 未在此列出的仓库会自动搜索所有 run
 sgl-project/sglang|pr-test-npu.yml
 vllm-project/vllm-ascend|pr_test_full.yaml
 modelscope/ms-swift|citest_npu.yaml

--- a/scripts/ci-audit/update_repo_md.py
+++ b/scripts/ci-audit/update_repo_md.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+从审计结果更新 docs/Repo.md 中的缓存状态表格。
+
+用法：
+  python3 update_repo_md.py <audit_result.md> <repos.txt> <docs/Repo.md>
+"""
+
+import re
+import sys
+from datetime import datetime, timezone, timedelta
+
+AUDIT_FILE = sys.argv[1]
+REPOS_FILE = sys.argv[2]
+REPO_MD    = sys.argv[3]
+
+CST = timezone(timedelta(hours=8))
+TODAY = datetime.now(CST).strftime("%Y-%m-%d")
+
+TABLE_START = "<!-- CACHE_AUDIT_TABLE_START -->"
+TABLE_END   = "<!-- CACHE_AUDIT_TABLE_END -->"
+
+# 内网 IP/域名前缀，检测到则视为已接入缓存
+INTRANET_PATTERNS = [
+    r'192\.168\.',
+    r'10\.',
+    r'172\.(1[6-9]|2[0-9]|3[01])\.',
+    r'localhost',
+    r'\.svc\.cluster\.local',
+    r'\.internal',
+]
+INTRANET_RE = re.compile('|'.join(INTRANET_PATTERNS))
+
+# ---------- 读取 repos.txt 默认值 ----------
+defaults = {}  # repo -> (pypi_default, apt_default)
+workflow_map = {}  # repo -> workflow_file (unused here, for reference)
+
+with open(REPOS_FILE) as f:
+    for line in f:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("|")
+        repo = parts[0].strip()
+        wf   = parts[1].strip() if len(parts) > 1 else ""
+        pypi = parts[2].strip() if len(parts) > 2 else ""
+        apt  = parts[3].strip() if len(parts) > 3 else ""
+        workflow_map[repo] = wf
+        defaults[repo] = (pypi or None, apt or None)
+
+# ---------- 解析审计结果 ----------
+# 格式：| repo | run | runner | PyPI 缓存 | APT 缓存 | 证据 |
+audit_results = {}  # repo -> (pypi, apt)
+
+UNDECIDED = {"⚙️", "⚠️", "🔍"}
+
+with open(AUDIT_FILE) as f:
+    for line in f:
+        if not line.startswith("| "):
+            continue
+        cols = [c.strip() for c in line.split("|")]
+        if len(cols) < 7:
+            continue
+        repo_col = cols[1]
+        pypi_col = cols[4]
+        apt_col  = cols[5]
+
+        # 提取 org/repo（去掉 markdown 链接格式）
+        m = re.search(r'([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)', repo_col)
+        if not m:
+            continue
+        repo = m.group(1)
+
+        evidence_col = cols[6] if len(cols) > 6 else ""
+
+        def resolve(val, evidence, default):
+            if val == "✅":
+                return "✅"
+            if val == "❌":
+                # ❌ 但证据里有内网 IP/域名，视为已接入
+                if INTRANET_RE.search(evidence):
+                    return "✅"
+                return "❌"
+            # ⚙️/⚠️/🔍 不确定，用默认值
+            return default  # None = 不知道
+
+        pypi = resolve(pypi_col, evidence_col, defaults.get(repo, (None, None))[0])
+        apt  = resolve(apt_col,  evidence_col, defaults.get(repo, (None, None))[1])
+        audit_results[repo] = (pypi, apt)
+
+# ---------- 读取 Repo.md，提取仓库顺序 ----------
+with open(REPO_MD) as f:
+    content = f.read()
+
+# 从现有表格或链接提取仓库列表（保持顺序）
+repos_in_md = re.findall(r'\[([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)\]\(https://github\.com/', content)
+# 去重保序
+seen = set()
+repos_ordered = []
+for r in repos_in_md:
+    if r not in seen:
+        seen.add(r)
+        repos_ordered.append(r)
+
+# ---------- 生成新表格 ----------
+def fmt(val):
+    if val is None:
+        return "-"
+    return val
+
+rows = []
+rows.append("| Repository | PyPI Cache | APT Cache | Last Checked |")
+rows.append("| :--- | :---: | :---: | :--- |")
+
+for repo in repos_ordered:
+    pypi, apt = audit_results.get(repo, (None, None))
+    # 如果审计没拿到值，用默认值
+    if pypi is None:
+        pypi = defaults.get(repo, (None, None))[0]
+    if apt is None:
+        apt = defaults.get(repo, (None, None))[1]
+    rows.append(
+        f"| [{repo}](https://github.com/{repo}) "
+        f"| {fmt(pypi)} | {fmt(apt)} | {TODAY} |"
+    )
+
+new_table = "\n".join([TABLE_START] + rows + [TABLE_END])
+
+# ---------- 替换 Repo.md 中的表格区域 ----------
+if TABLE_START in content and TABLE_END in content:
+    new_content = re.sub(
+        re.escape(TABLE_START) + r".*?" + re.escape(TABLE_END),
+        new_table,
+        content,
+        flags=re.DOTALL
+    )
+else:
+    # 第一次运行，把整个内容替换成带表格的版本
+    new_content = content.rstrip() + "\n\n" + new_table + "\n"
+
+with open(REPO_MD, "w") as f:
+    f.write(new_content)
+
+print(f"Updated {REPO_MD} with {len(repos_ordered)} repos ({TODAY})")


### PR DESCRIPTION
## 变更内容

### 判断逻辑
- 区分三种状态：✅ 正面证据 / ❌ 反面证据 / ⚙️ 无证据
- `Looking in indexes:` 运行时输出优先级高于配置，修复 pip config set 误判
- 内网 IP（192.168.x/10.x/svc.cluster.local 等）视为已接入，❌ 自动升级为 ✅
- 跳过无安装操作的 job（docs-check、lint-only 等）
- 同时搜索 success 和 failure 的 run，排除 skipped job

### 覆盖范围
- 从 `docs/Repo.md` 动态获取仓库列表，无需手动维护
- `repos.txt` 只存 workflow 文件映射和默认值（`org/repo|workflow.yml|pypi_default|apt_default`）

### 输出与展示
- 每行证据带溯源日志链接，可直接跳转原始日志
- 审计结果自动写入 `docs/Repo.md` 表格并推送到 main
- GitHub Pages 自动更新展示最新缓存状态