### PR TITLE
ci: vllm-omni 默认值改为不确定，去掉 [skip ci]

### DIFF
--- a/.github/workflows/check-cache-audit.yml
+++ b/.github/workflows/check-cache-audit.yml
@@ -64,7 +64,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to Repo.md"
           else
-            git commit -m "docs: update cache audit status in Repo.md [skip ci]"
+            git commit -m "docs: update cache audit status in Repo.md"
             git push "https://x-access-token:${{ secrets.CACHE_AUDIT_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:main
           fi
 


### PR DESCRIPTION
- vllm-omni 无法检测到缓存使用情况，默认值从 ✅ 改为空（显示 -）
- 去掉 commit message 里的 [skip ci]，审计更新 Repo.md 后正常触发 GitHub Pages 重新部署