### PR TITLE
ci: 在 Repo.md 页脚加入最新审计 Action run 链接

### DIFF
--- a/.github/workflows/check-cache-audit.yml
+++ b/.github/workflows/check-cache-audit.yml
@@ -54,7 +54,8 @@ jobs:
           python3 scripts/ci-audit/update_repo_md.py \
             audit_result.md \
             scripts/ci-audit/repos.txt \
-            docs/Repo.md
+            docs/Repo.md \
+            "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Commit updated Repo.md
         run: |

--- a/scripts/ci-audit/update_repo_md.py
+++ b/scripts/ci-audit/update_repo_md.py
@@ -3,7 +3,7 @@
 从审计结果更新 docs/Repo.md 中的缓存状态表格。
 
 用法：
-  python3 update_repo_md.py <audit_result.md> <repos.txt> <docs/Repo.md>
+  python3 update_repo_md.py <audit_result.md> <repos.txt> <docs/Repo.md> [run_url]
 """
 
 import re
@@ -13,6 +13,7 @@ from datetime import datetime, timezone, timedelta
 AUDIT_FILE = sys.argv[1]
 REPOS_FILE = sys.argv[2]
 REPO_MD    = sys.argv[3]
+RUN_URL    = sys.argv[4] if len(sys.argv) > 4 else None
 
 CST = timezone(timedelta(hours=8))
 TODAY = datetime.now(CST).strftime("%Y-%m-%d")
@@ -126,6 +127,14 @@ for repo in repos_ordered:
 
 new_table = "\n".join([TABLE_START] + rows + [TABLE_END])
 
+# 构建注释行
+if RUN_URL:
+    footer = f"> Cache audit runs daily. ✅ = confirmed in use · ❌ = confirmed NOT in use · - = unknown · [Latest audit run]({RUN_URL})"
+else:
+    footer = "> Cache audit runs daily. ✅ = confirmed in use · ❌ = confirmed NOT in use · - = unknown"
+
+FOOTER_RE = re.compile(r'^> Cache audit runs daily\..*$', re.MULTILINE)
+
 # ---------- 替换 Repo.md 中的表格区域 ----------
 if TABLE_START in content and TABLE_END in content:
     new_content = re.sub(
@@ -135,8 +144,13 @@ if TABLE_START in content and TABLE_END in content:
         flags=re.DOTALL
     )
 else:
-    # 第一次运行，把整个内容替换成带表格的版本
     new_content = content.rstrip() + "\n\n" + new_table + "\n"
+
+# 替换或添加 footer
+if FOOTER_RE.search(new_content):
+    new_content = FOOTER_RE.sub(footer, new_content)
+else:
+    new_content = new_content.rstrip() + "\n\n" + footer + "\n"
 
 with open(REPO_MD, "w") as f:
     f.write(new_content)


### PR DESCRIPTION
审计跑完后，在 Repo.md 表格下方的注释行里加入本次 Action run 的链接，方便溯源。链接格式：[Latest audit run](https://github.com/.../actions/runs/XXXXX)