### PR TITLE
docs: add package cache usage guide (en/zh)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ If your organization would like to use GitHub Actions runners, configure your or
 
 If your organization would like to use Buildkite CI with Ascend NPU, follow the [Buildkite CI Integration Guide](./user-manual-buildkite-en.md).
 
+To speed up your CI by caching PyPI, APT, yum/dnf and rustup packages inside the cluster, see the [Package Cache Guide](./user-manual-cache-en.md).
+
 If you encounter any issues while using the documentation, please submit an [issue](https://github.com/ascend-gha-runners/docs/issues).
 
 # Future Plans

--- a/docs/user-manual-cache-en.md
+++ b/docs/user-manual-cache-en.md
@@ -1,0 +1,317 @@
+# Package Cache Guide
+
+To make CI on Ascend NPU runners faster and more reliable, our clusters run an in-cluster
+caching proxy for common package managers (PyPI, APT, yum/dnf, rustup). On a cache hit,
+packages are served from inside the cluster instead of being downloaded from the public
+internet on every run — this avoids network flakiness, upstream rate limits, and
+repeated downloads of the same wheels and `.deb`/`.rpm` files.
+
+The cache is **opt-in**: it does not take effect automatically. You add a few setup
+commands to your workflow so that `pip` / `apt` / `dnf` point at the cache service.
+
+The [Integrated Repositories](Repo.md) page shows, per repository, whether the PyPI and
+APT caches are currently in use.
+
+## How it works
+
+The cache is an nginx reverse proxy with on-disk storage, deployed inside the same
+Kubernetes cluster as the runners. It transparently proxies upstream mirrors
+(Huawei Cloud, official PyPI, PyTorch, etc.), caches the responses, and serves the cached
+copy on subsequent requests.
+
+```
+┌───────────────────────────────┐      cache HIT       ┌──────────────────────────┐
+│  Your CI job (runner pod /     │  ──────────────────▶ │  cache-service (nginx)   │
+│  container.image)              │                      │  in-cluster, on-disk     │
+│  pip / apt / dnf / rustup      │  ◀──────────────────  │  cache                   │
+└───────────────────────────────┘    cached package    └────────────┬─────────────┘
+                                                                     │ cache MISS
+                                                                     ▼
+                                                    upstream mirrors (Huawei Cloud,
+                                                    pypi.org, pytorch.org, ...)
+```
+
+!!! important
+    The cache service has a **cluster-internal** address
+    (`cache-service.nginx-pypi-cache.svc.cluster.local`). It is only reachable from
+    **inside a running job**, i.e. from within your `container.image`. It is not
+    reachable from your laptop or from GitHub-hosted runners. All the commands below are
+    meant to run as steps inside an Ascend NPU runner job.
+
+## Prerequisites
+
+- Your repository is already onboarded to Ascend NPU runners. If not, follow the
+  [GitHub Actions Integration Guide](user-manual-gha-en.md) first.
+- Your job runs inside a `container.image` on an Ascend runner (see the workflow example
+  at the end).
+
+## Service endpoints
+
+All package managers talk to the same service, `cache-service.nginx-pypi-cache.svc.cluster.local`,
+on different ports:
+
+| Package manager | Port | Endpoint |
+| :--- | :---: | :--- |
+| pip / PyPI | 80 | `http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple` |
+| PyTorch wheels | 80 | `http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/<variant>` |
+| APT (Ubuntu / Debian) | 8081 | `cache-service.nginx-pypi-cache.svc.cluster.local:8081` |
+| rustup | 8082 | `http://cache-service.nginx-pypi-cache.svc.cluster.local:8082` |
+| yum / dnf (openEuler) | 8083 | `http://cache-service.nginx-pypi-cache.svc.cluster.local:8083` |
+
+---
+
+## PyPI (pip)
+
+**What you need to do**:
+
+Point `pip` at the cache before installing any dependencies:
+
+```bash
+pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+```
+
+The `trusted-host` line is required because the cache is served over plain HTTP inside the
+cluster; without it `pip` refuses the insecure index.
+
+The PyPI cache is backed by the Huawei Cloud mirror and automatically falls back to
+official `pypi.org` / `files.pythonhosted.org` when the mirror has not yet synced a freshly
+published package, so you do not need a separate fallback index.
+
+!!! tip "Using uv"
+    If your project uses [uv](https://github.com/astral-sh/uv), set the equivalent
+    environment variables instead of (or in addition to) the `pip config` commands:
+
+    ```bash
+    export UV_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    export UV_INSECURE_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+    ```
+
+**How to verify**:
+
+- `pip install` succeeds and, on a second run, completes noticeably faster.
+- The response carries a cache-status header. You can check it directly:
+
+  ```bash
+  curl -sI http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple/numpy/ \
+    | grep -i x-pypi-cache
+  # X-Pypi-Cache: HIT   (MISS on the first request, HIT afterwards)
+  ```
+
+### PyTorch wheels (optional)
+
+To install PyTorch and its companion wheels through the cache, use the `/whl/<variant>`
+index (mirrors `download.pytorch.org/whl/<variant>`):
+
+```bash
+pip install torch --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+```
+
+Replace `cpu` with the variant you need (e.g. `cpu`, `cu121`). The cache rewrites the
+PyTorch index links so wheel downloads stay inside the cluster.
+
+---
+
+## APT (Ubuntu / Debian)
+
+**What you need to do**:
+
+Rewrite the upstream host in your APT sources to the cache (port `8081`), then run
+`apt-get update` as usual. The exact file depends on the base image of your container.
+
+=== "Ubuntu 22.04 or earlier"
+
+    ```bash
+    sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list
+    apt-get update
+    ```
+
+=== "Ubuntu 24.04 or later (deb822)"
+
+    ```bash
+    sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list.d/ubuntu.sources
+    apt-get update
+    ```
+
+=== "Debian 11 or earlier"
+
+    ```bash
+    sed -Ei 's@deb.debian.org@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list
+    apt-get update
+    ```
+
+=== "Debian 12 or later (deb822)"
+
+    ```bash
+    sed -Ei 's@deb.debian.org@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list.d/debian.sources
+    apt-get update
+    ```
+
+!!! note
+    Newer Ubuntu/Debian images use the [deb822](https://manpages.debian.org/bookworm/dpkg-dev/deb822.5.en.html)
+    format, where the sources live in `*.sources` files under `/etc/apt/sources.list.d/`
+    rather than in `/etc/apt/sources.list`. If you are unsure which your image uses, check
+    which file exists.
+
+**How to verify**:
+
+- `apt-get update` and `apt-get install` succeed, and repeated installs are faster.
+- Response headers from the cache include `X-Cache-Status: HIT`.
+
+---
+
+## yum / dnf (openEuler)
+
+**What you need to do**:
+
+The cache listens on port `8083` for openEuler repos and proxies
+`repo.huaweicloud.com/openeuler/...`. Replace the upstream host in every `.repo` file with
+the cache service, then rebuild the metadata cache:
+
+```bash
+sed -Ei \
+  -e 's@https?://repo\.openeuler\.org@http://cache-service.nginx-pypi-cache.svc.cluster.local:8083@g' \
+  -e 's@https?://mirrors\.openeuler\.org@http://cache-service.nginx-pypi-cache.svc.cluster.local:8083@g' \
+  /etc/yum.repos.d/*.repo
+dnf clean all && dnf makecache
+```
+
+If your image already points its `baseurl` at Huawei Cloud, rewrite that host instead (the
+cache strips the `/openeuler` prefix it would otherwise duplicate):
+
+```bash
+sed -Ei \
+  's@https?://repo\.huaweicloud\.com/openeuler@http://cache-service.nginx-pypi-cache.svc.cluster.local:8083@g' \
+  /etc/yum.repos.d/*.repo
+```
+
+!!! warning "Keep `gpgcheck=1`"
+    RPM signatures are verified end-to-end, so serving packages over plain HTTP from the
+    cache is safe. Do **not** turn off `gpgcheck` — that is what would actually break
+    signature verification.
+
+!!! note "metalink"
+    The `metalink=` line is rewritten by the `sed` above and will return 404 from the
+    cache (metalink is not proxied). `dnf` falls back to `baseurl=` automatically —
+    functional, just one extra round-trip. To skip it entirely:
+
+    ```bash
+    sed -i '/^metalink=/d' /etc/yum.repos.d/*.repo
+    ```
+
+**How to verify**:
+
+- `dnf makecache` / `dnf install` succeed against the rewritten repos.
+- Response headers from the cache include `X-Yum-Cache: HIT`.
+
+---
+
+## rustup (optional)
+
+**What you need to do**:
+
+If your build installs a Rust toolchain via `rustup`, point it at the cache on port `8082`
+(backed by the Huawei Cloud rustup mirror):
+
+```bash
+export RUSTUP_DIST_SERVER=http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup
+export RUSTUP_UPDATE_ROOT=http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup/rustup
+```
+
+**How to verify**:
+
+- `rustup` / `rustup-init` downloads complete, and toolchain tarballs come back faster on
+  repeat runs.
+- Response headers from the cache include `X-Rustup-Cache: HIT`.
+
+---
+
+## Full workflow example
+
+A complete GitHub Actions workflow that runs on an Ascend NPU runner and uses the PyPI and
+APT caches:
+
+```yaml
+name: NPU CI (with cache)
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: linux-aarch64-a2-1
+    container:
+      image: ascendai/cann:latest
+    steps:
+      - name: Configure package caches
+        run: |
+          # PyPI
+          pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+          pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+          # APT (Ubuntu 22.04 base; adjust for your image)
+          sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+            /etc/apt/sources.list
+
+      - uses: actions/checkout@v4
+
+      - name: Install system deps
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git
+
+      - name: Install Python deps
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          npu-smi info
+          pytest -v
+```
+
+!!! tip
+    Put the cache-configuration step **first**, before `checkout` and any
+    `pip install` / `apt-get install`, so every later step benefits from the cache.
+
+---
+
+## FAQ
+
+**Q1: Do I have to use the cache?**
+
+No. It is opt-in and purely a speed/reliability optimization. Without it, your jobs still
+work by going to the public mirrors directly.
+
+**Q2: The cache address does not resolve / connection refused.**
+
+- Confirm the commands run **inside** a job on an Ascend NPU runner (within
+  `container.image`). The service address is cluster-internal and is not reachable from
+  outside the cluster.
+- Confirm you used the correct port for the package manager (80 for pip, 8081 for APT,
+  8083 for yum/dnf, 8082 for rustup).
+
+**Q3: A package is missing or out of date in the cache.**
+
+The PyPI cache automatically falls back to official `pypi.org` when the upstream mirror
+has not synced a freshly published package, so this should be rare. If you still hit a
+stale entry, please [open a discussion](https://github.com/ascend-gha-runners/docs/discussions).
+
+**Q4: How do I confirm my repository is counted as "using" the cache?**
+
+See the [Integrated Repositories](Repo.md) page — it runs a daily audit and shows whether
+the PyPI and APT caches are in use for each integrated repository.
+
+---
+
+## Feedback & Support
+
+If you encounter any issues configuring or using the cache, please
+[create a discussion](https://github.com/ascend-gha-runners/docs/discussions).
+
+When submitting, please provide:
+
+- Project name and Git repository URL
+- Which package manager and which command failed
+- The error message and, if possible, the relevant `X-*-Cache` response header

--- a/docs/user-manual-cache-zh.md
+++ b/docs/user-manual-cache-zh.md
@@ -1,0 +1,303 @@
+# 软件包缓存使用指导
+
+为了让昇腾 NPU runner 上的 CI 更快、更稳定，我们在集群内为常用包管理器（PyPI、APT、
+yum/dnf、rustup）部署了一套缓存代理。命中缓存时，软件包直接从集群内部返回，而不必每次都
+从公网下载——这样可以避免网络抖动、上游限流，以及重复下载相同的 wheel 和 `.deb`/`.rpm`
+文件。
+
+缓存是**按需开启**的：它不会自动生效。你需要在 workflow 中加入几条配置命令，让
+`pip` / `apt` / `dnf` 指向缓存服务。
+
+[已接入仓库](Repo.md)页面会按仓库展示 PyPI 与 APT 缓存当前是否已启用。
+
+## 工作原理
+
+缓存是一个带磁盘存储的 nginx 反向代理，与 runner 部署在同一个 Kubernetes 集群内。它会透明
+地代理上游镜像（华为云、官方 PyPI、PyTorch 等），缓存其响应，并在后续请求中直接返回缓存副本。
+
+```
+┌───────────────────────────────┐      命中缓存        ┌──────────────────────────┐
+│  你的 CI job（runner pod /     │  ──────────────────▶ │  cache-service (nginx)   │
+│  container.image）             │                      │  集群内，磁盘缓存        │
+│  pip / apt / dnf / rustup      │  ◀──────────────────  │                          │
+└───────────────────────────────┘     返回缓存包       └────────────┬─────────────┘
+                                                                     │ 未命中
+                                                                     ▼
+                                                       上游镜像（华为云、pypi.org、
+                                                       pytorch.org ...）
+```
+
+!!! important
+    缓存服务使用的是**集群内部**地址
+    （`cache-service.nginx-pypi-cache.svc.cluster.local`）。它只能从**正在运行的 job
+    内部**访问，也就是你的 `container.image` 容器内。它无法从你的本地电脑或 GitHub 托管
+    runner 访问。下文所有命令都应作为昇腾 NPU runner job 的步骤来执行。
+
+## 准备工作
+
+- 你的仓库已经接入昇腾 NPU runner。如果还没有，请先参考
+  [GitHub Actions 接入昇腾算力指导](user-manual-gha-zh.md)。
+- 你的 job 在昇腾 runner 上、通过 `container.image` 运行（见文末的 workflow 示例）。
+
+## 服务端点
+
+所有包管理器都访问同一个服务 `cache-service.nginx-pypi-cache.svc.cluster.local`，只是端口
+不同：
+
+| 包管理器 | 端口 | 端点 |
+| :--- | :---: | :--- |
+| pip / PyPI | 80 | `http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple` |
+| PyTorch wheel | 80 | `http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/<变体>` |
+| APT（Ubuntu / Debian） | 8081 | `cache-service.nginx-pypi-cache.svc.cluster.local:8081` |
+| rustup | 8082 | `http://cache-service.nginx-pypi-cache.svc.cluster.local:8082` |
+| yum / dnf（openEuler） | 8083 | `http://cache-service.nginx-pypi-cache.svc.cluster.local:8083` |
+
+---
+
+## PyPI（pip）
+
+**你需要做什么**：
+
+在安装任何依赖之前，先让 `pip` 指向缓存：
+
+```bash
+pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+```
+
+`trusted-host` 这一行是必需的，因为集群内缓存是通过纯 HTTP 提供的；不加这一行，`pip` 会
+拒绝这个“不安全”的 index。
+
+PyPI 缓存以华为云镜像为后端，当镜像尚未同步到刚发布的新包时，会自动回退到官方
+`pypi.org` / `files.pythonhosted.org`，所以你无需再额外配置回退源。
+
+!!! tip "使用 uv"
+    如果你的项目使用 [uv](https://github.com/astral-sh/uv)，请改用（或同时设置）对应的
+    环境变量：
+
+    ```bash
+    export UV_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    export UV_INSECURE_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+    ```
+
+**怎么验证这步完成**：
+
+- `pip install` 成功，且第二次运行明显更快。
+- 响应会带有缓存状态头，你可以直接查看：
+
+  ```bash
+  curl -sI http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple/numpy/ \
+    | grep -i x-pypi-cache
+  # X-Pypi-Cache: HIT   （首次请求为 MISS，之后为 HIT）
+  ```
+
+### PyTorch wheel（可选）
+
+如需通过缓存安装 PyTorch 及其配套 wheel，使用 `/whl/<变体>` index（镜像
+`download.pytorch.org/whl/<变体>`）：
+
+```bash
+pip install torch --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+```
+
+把 `cpu` 替换为你需要的变体（如 `cpu`、`cu121`）。缓存会重写 PyTorch index 中的链接，
+确保 wheel 下载始终留在集群内部。
+
+---
+
+## APT（Ubuntu / Debian）
+
+**你需要做什么**：
+
+把 APT 源里的上游主机替换为缓存（端口 `8081`），然后照常执行 `apt-get update`。具体改哪个
+文件取决于你容器的基础镜像。
+
+=== "Ubuntu 22.04 及更早"
+
+    ```bash
+    sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list
+    apt-get update
+    ```
+
+=== "Ubuntu 24.04 及更新（deb822）"
+
+    ```bash
+    sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list.d/ubuntu.sources
+    apt-get update
+    ```
+
+=== "Debian 11 及更早"
+
+    ```bash
+    sed -Ei 's@deb.debian.org@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list
+    apt-get update
+    ```
+
+=== "Debian 12 及更新（deb822）"
+
+    ```bash
+    sed -Ei 's@deb.debian.org@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+      /etc/apt/sources.list.d/debian.sources
+    apt-get update
+    ```
+
+!!! note
+    较新的 Ubuntu/Debian 镜像采用
+    [deb822](https://manpages.debian.org/bookworm/dpkg-dev/deb822.5.en.html) 格式，源
+    定义放在 `/etc/apt/sources.list.d/` 下的 `*.sources` 文件里，而不是
+    `/etc/apt/sources.list`。如果不确定你的镜像用的是哪种，看哪个文件存在即可。
+
+**怎么验证这步完成**：
+
+- `apt-get update` 和 `apt-get install` 成功，且重复安装更快。
+- 缓存返回的响应头中包含 `X-Cache-Status: HIT`。
+
+---
+
+## yum / dnf（openEuler）
+
+**你需要做什么**：
+
+缓存在端口 `8083` 上服务 openEuler 仓库，代理 `repo.huaweicloud.com/openeuler/...`。把每个
+`.repo` 文件中的上游主机替换为缓存服务，然后重建元数据缓存：
+
+```bash
+sed -Ei \
+  -e 's@https?://repo\.openeuler\.org@http://cache-service.nginx-pypi-cache.svc.cluster.local:8083@g' \
+  -e 's@https?://mirrors\.openeuler\.org@http://cache-service.nginx-pypi-cache.svc.cluster.local:8083@g' \
+  /etc/yum.repos.d/*.repo
+dnf clean all && dnf makecache
+```
+
+如果你的镜像已经把 `baseurl` 指向华为云，则改写该主机（缓存会去掉它本会重复的 `/openeuler`
+前缀）：
+
+```bash
+sed -Ei \
+  's@https?://repo\.huaweicloud\.com/openeuler@http://cache-service.nginx-pypi-cache.svc.cluster.local:8083@g' \
+  /etc/yum.repos.d/*.repo
+```
+
+!!! warning "保持 `gpgcheck=1`"
+    RPM 签名是端到端校验的，所以通过纯 HTTP 从缓存获取软件包是安全的。**不要**关闭
+    `gpgcheck`——关掉它才会真正破坏签名校验。
+
+!!! note "metalink"
+    上面的 `sed` 会改写 `metalink=` 行，使其从缓存返回 404（缓存不代理 metalink）。`dnf`
+    会自动回退到 `baseurl=`——功能正常，只是多一次往返。若想彻底去掉这一行：
+
+    ```bash
+    sed -i '/^metalink=/d' /etc/yum.repos.d/*.repo
+    ```
+
+**怎么验证这步完成**：
+
+- 针对改写后的仓库，`dnf makecache` / `dnf install` 成功。
+- 缓存返回的响应头中包含 `X-Yum-Cache: HIT`。
+
+---
+
+## rustup（可选）
+
+**你需要做什么**：
+
+如果你的构建通过 `rustup` 安装 Rust 工具链，将其指向端口 `8082` 上的缓存（以华为云 rustup
+镜像为后端）：
+
+```bash
+export RUSTUP_DIST_SERVER=http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup
+export RUSTUP_UPDATE_ROOT=http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup/rustup
+```
+
+**怎么验证这步完成**：
+
+- `rustup` / `rustup-init` 下载成功，且工具链压缩包在重复运行时更快返回。
+- 缓存返回的响应头中包含 `X-Rustup-Cache: HIT`。
+
+---
+
+## 完整 workflow 示例
+
+一个在昇腾 NPU runner 上运行、并使用 PyPI 与 APT 缓存的完整 GitHub Actions workflow：
+
+```yaml
+name: NPU CI (with cache)
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: linux-aarch64-a2-1
+    container:
+      image: ascendai/cann:latest
+    steps:
+      - name: Configure package caches
+        run: |
+          # PyPI
+          pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+          pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+          # APT（基础镜像为 Ubuntu 22.04；请按你的镜像调整）
+          sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' \
+            /etc/apt/sources.list
+
+      - uses: actions/checkout@v4
+
+      - name: Install system deps
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git
+
+      - name: Install Python deps
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          npu-smi info
+          pytest -v
+```
+
+!!! tip
+    把配置缓存的步骤放在**最前面**，先于 `checkout` 和任何 `pip install` /
+    `apt-get install`，这样后续每一步都能享受到缓存。
+
+---
+
+## 常见问题
+
+**Q1：我必须使用缓存吗？**
+
+不必。缓存是按需开启的，纯粹是为了提升速度与稳定性。即使不用，你的 job 仍可直接访问公网
+镜像正常运行。
+
+**Q2：缓存地址无法解析 / 连接被拒绝。**
+
+- 确认命令是在昇腾 NPU runner 的 job **内部**（`container.image` 容器内）执行的。该服务
+  地址是集群内部地址，集群外无法访问。
+- 确认包管理器使用了正确的端口（pip 用 80，APT 用 8081，yum/dnf 用 8083，rustup 用
+  8082）。
+
+**Q3：缓存里缺少某个包或版本过旧。**
+
+PyPI 缓存在上游镜像尚未同步新发布的包时会自动回退到官方 `pypi.org`，所以这种情况应当很
+少见。如果仍遇到过期条目，请[提出 discussion](https://github.com/ascend-gha-runners/docs/discussions)。
+
+**Q4：怎么确认我的仓库被算作“已使用”缓存？**
+
+查看[已接入仓库](Repo.md)页面——它每日进行一次审计，展示每个已接入仓库的 PyPI 与 APT
+缓存是否已启用。
+
+---
+
+## 反馈与支持
+
+如果你在配置或使用缓存过程中遇到任何问题，请
+[提出 discussion](https://github.com/ascend-gha-runners/docs/discussions)。
+
+提交时，请提供以下信息：
+
+- 项目名称和 Git 仓库地址
+- 是哪个包管理器、哪条命令失败
+- 错误信息，以及（如有可能）相关的 `X-*-Cache` 响应头

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,5 +55,9 @@ nav:
     - user-manual-buildkite-en.md
   - Buildkite Guide Zh:
     - user-manual-buildkite-zh.md
+  - Package Cache Guide En:
+    - user-manual-cache-en.md
+  - Package Cache Guide Zh:
+    - user-manual-cache-zh.md
   - Integrated repo:
     - Repo.md


### PR DESCRIPTION
## What

Adds a new documentation page explaining **how to use the in-cluster package cache** on Ascend NPU runners, in both English and Chinese:

- `docs/user-manual-cache-en.md`
- `docs/user-manual-cache-zh.md`

`Repo.md` already shows a per-repo PyPI/APT cache audit table, but there was no page describing what the cache is or how to enable it. This fills that gap.

## Contents

Covers all package managers the cache proxy supports (`nginx-pypi-cache`):

| Manager | Port | Endpoint |
| :--- | :---: | :--- |
| pip / PyPI | 80 | `/pypi/simple` |
| PyTorch wheels | 80 | `/whl/<variant>` |
| APT (Ubuntu / Debian) | 8081 | `:8081` |
| rustup | 8082 | `:8082` |
| yum / dnf (openEuler) | 8083 | `:8083` |

Each section gives copy-paste setup commands, a verification step (`X-*-Cache` headers), plus a full end-to-end workflow example and FAQ. Notes that the cache is **opt-in**, cluster-internal (only reachable from inside the job container), and configured manually per package manager.

## Also

- Wires both pages into the `mkdocs.yml` nav (after the Buildkite guides).
- Adds a link from the Getting Started page.

Commands are sourced directly from the `nginx-pypi-cache` deployment config and its README.