### PR TITLE
ci: add CCache and uv monitoring columns to cache audit

### DIFF
--- a/docs/Repo.md
+++ b/docs/Repo.md
@@ -3,20 +3,20 @@
 `NPU runners` have been integrated into the following repositories:
 
 <!-- CACHE_AUDIT_TABLE_START -->
-| Repository | PyPI Cache | APT Cache | Last Checked |
-| :--- | :---: | :---: | :--- |
-| [vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend) | ✅ | ✅ | 2026-06-08 |
-| [vllm-project/vllm-omni](https://github.com/vllm-project/vllm-omni) | - | - | 2026-06-08 |
-| [Ascend/Ascend-CI](https://github.com/Ascend/Ascend-CI) | ❌ | ❌ | 2026-06-08 |
-| [pytorch-fdn/accelerator-integration-wg](https://github.com/pytorch-fdn/accelerator-integration-wg) | - | - | 2026-06-08 |
-| [sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu) | ✅ | ✅ | 2026-06-08 |
-| [sgl-project/sglang](https://github.com/sgl-project/sglang) | ✅ | ✅ | 2026-06-08 |
-| [volcengine/verl](https://github.com/volcengine/verl) | ✅ | ✅ | 2026-06-08 |
-| [hiyouga/LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) | ✅ | ✅ | 2026-06-08 |
-| [modelscope/ms-swift](https://github.com/modelscope/ms-swift) | ✅ | ✅ | 2026-06-08 |
-| [tile-ai/tilelang-ascend](https://github.com/tile-ai/tilelang-ascend) | ✅ | ✅ | 2026-06-08 |
-| [triton-lang/triton-ascend](https://github.com/triton-lang/triton-ascend) | ✅ | - | 2026-06-08 |
+| Repository | PyPI Cache | APT Cache | CCache | uv | Last Checked |
+| :--- | :---: | :---: | :---: | :---: | :--- |
+| [vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend) | ✅ | ✅ | - | - | 2026-06-08 |
+| [vllm-project/vllm-omni](https://github.com/vllm-project/vllm-omni) | - | - | - | - | 2026-06-08 |
+| [Ascend/Ascend-CI](https://github.com/Ascend/Ascend-CI) | ❌ | ❌ | - | - | 2026-06-08 |
+| [pytorch-fdn/accelerator-integration-wg](https://github.com/pytorch-fdn/accelerator-integration-wg) | - | - | - | - | 2026-06-08 |
+| [sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu) | ✅ | ✅ | - | - | 2026-06-08 |
+| [sgl-project/sglang](https://github.com/sgl-project/sglang) | ✅ | ✅ | - | - | 2026-06-08 |
+| [volcengine/verl](https://github.com/volcengine/verl) | ✅ | ✅ | - | - | 2026-06-08 |
+| [hiyouga/LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) | ✅ | ✅ | - | - | 2026-06-08 |
+| [modelscope/ms-swift](https://github.com/modelscope/ms-swift) | ✅ | ✅ | - | - | 2026-06-08 |
+| [tile-ai/tilelang-ascend](https://github.com/tile-ai/tilelang-ascend) | ✅ | ✅ | - | - | 2026-06-08 |
+| [triton-lang/triton-ascend](https://github.com/triton-lang/triton-ascend) | ✅ | - | ✅ | - | 2026-06-08 |
 <!-- CACHE_AUDIT_TABLE_END -->
 
-> 缓存状态每日自动审计更新。若对结果有疑问，可查看 [最新审计日志](https://github.com/ascend-gha-runners/docs/actions/runs/27124041452) 了解详情。
+> 缓存状态每日自动审计更新。
 > ✅ = 已确认接入 · ❌ = 已确认未接入 · - = 暂无数据

--- a/docs/feature.md
+++ b/docs/feature.md
@@ -1,0 +1,94 @@
+# Platform Features
+
+## Cache Service
+
+To reduce bandwidth pressure and speed up CI builds, we deploy an in-cluster nginx cache service that proxies common package registries. All runner pods can access it via the internal service address.
+
+**Service address:** `cache-service.nginx-pypi-cache.svc.cluster.local`
+
+---
+
+### PyPI Cache (Port 80)
+
+Proxies Python package index. Falls back to `pypi.org` when the upstream mirror returns 404.
+
+**Configure in your workflow:**
+
+```yaml
+- name: Configure pip cache
+  run: |
+    pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+```
+
+**Or via environment variable:**
+
+```yaml
+env:
+  PIP_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+  PIP_TRUSTED_HOST: cache-service.nginx-pypi-cache.svc.cluster.local
+```
+
+**PyTorch wheels** are also cached. Use the `/whl` path:
+
+```yaml
+- name: Install PyTorch via cache
+  run: |
+    pip install torch --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+```
+
+---
+
+### APT Cache (Port 8081)
+
+Proxies Ubuntu/Debian package repositories (`ports.ubuntu.com`, `archive.ubuntu.com`).
+
+**Configure in your workflow:**
+
+```yaml
+- name: Configure apt cache
+  run: |
+    sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
+```
+
+---
+
+### Rust / rustup Cache (Port 8082)
+
+Proxies `mirrors.huaweicloud.com/rustup` for Rust toolchain downloads.
+
+**Configure in your workflow:**
+
+```yaml
+- name: Configure rustup cache
+  env:
+    RUSTUP_DIST_SERVER: http://cache-service.nginx-pypi-cache.svc.cluster.local:8082
+    RUSTUP_UPDATE_ROOT: http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup
+  run: |
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+```
+
+---
+
+### YUM / DNF Cache (Port 8083)
+
+Proxies `repo.huaweicloud.com/openeuler` for openEuler RPM packages.
+
+**Configure in your workflow:**
+
+```yaml
+- name: Configure yum cache
+  run: |
+    sed -i 's|https://repo.openeuler.org|http://cache-service.nginx-pypi-cache.svc.cluster.local:8083|g' /etc/yum.repos.d/*.repo
+```
+
+---
+
+### Summary
+
+| Cache Type | Port | Upstream | Client |
+| :--- | :---: | :--- | :--- |
+| PyPI | 80 | repo.huaweicloud.com + pypi.org fallback | pip / uv |
+| APT | 8081 | ports/archive.ubuntu.com | apt-get |
+| Rust | 8082 | mirrors.huaweicloud.com/rustup | rustup |
+| YUM | 8083 | repo.huaweicloud.com/openeuler | dnf / yum |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,3 +57,5 @@ nav:
     - user-manual-buildkite-zh.md
   - Integrated repo:
     - Repo.md
+  - Features:
+    - feature.md

--- a/scripts/ci-audit/check_cache_from_logs.sh
+++ b/scripts/ci-audit/check_cache_from_logs.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 #   MAX_NPU_SEARCH   — 自动模式最多搜多少个 run，默认 100
 #   PYPI_CACHE_HOST  — PyPI 缓存主机名
 #   APT_CACHE_PORT   — APT 缓存端口
+#   CCACHE_KEYWORD   — ccache 检测关键词（默认 "ccache"）
 # ==============================================================================
 
 if ! command -v jq &>/dev/null; then
@@ -42,6 +43,7 @@ fi
 PYPI_CACHE_HOST="${PYPI_CACHE_HOST:-cache-service.nginx-pypi-cache.svc.cluster.local}"
 APT_CACHE_PORT="${APT_CACHE_PORT:-8081}"
 APT_CACHE_HOST="${APT_CACHE_HOST:-}"
+CCACHE_KEYWORD="${CCACHE_KEYWORD:-ccache}"
 RUNNER_FILTER="${RUNNER_FILTER:-linux-aarch64,linux-amd64}"
 MAX_NPU_SEARCH="${MAX_NPU_SEARCH:-100}"
 PER_PAGE="${PER_PAGE:-30}"
@@ -61,19 +63,22 @@ mkdir -p "$LOG_DIR"
 echo "Log-based Cache Audit Configuration:"
 echo " - PyPI Cache Host:  $PYPI_CACHE_HOST"
 echo " - APT Pattern:      $APT_PATTERN"
+echo " - CCache Keyword:   $CCACHE_KEYWORD"
 echo " - Runner Filter:    $RUNNER_FILTER (regex: $RUNNER_REGEX)"
 echo " - Max NPU Search:   $MAX_NPU_SEARCH runs"
 echo "------------------------------------------------------------------"
 
 STAT_PYPI=0
 STAT_APT=0
+STAT_CCACHE=0
+STAT_UV=0
 STAT_NO_CACHE=0
 STAT_NO_NPU=0
 STAT_ERROR=0
 TOTAL=0
 
-echo "| 仓库 (Repository) | Run | Runner | PyPI 缓存 | APT 缓存 | 证据 (Evidence) |"
-echo "| :--- | :--- | :--- | :---: | :---: | :--- |"
+echo "| 仓库 (Repository) | Run | Runner | PyPI 缓存 | APT 缓存 | CCache | uv | 证据 (Evidence) |"
+echo "| :--- | :--- | :--- | :---: | :---: | :---: | :---: | :--- |"
 
 while IFS= read -r LINE || [ -n "$LINE" ]; do
     [[ -z "$LINE" || "$LINE" =~ ^[[:space:]]*# ]] && continue
@@ -160,6 +165,8 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
     # ==================================================================
     repo_pypi=false
     repo_apt=false
+    repo_ccache=false
+    repo_uv=false
     repo_evidence=""
     repo_run=""
     repo_runner=""
@@ -167,10 +174,10 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
 
     if [ "$npu_found" = false ]; then
         if [ "$runs_scanned" -gt 0 ]; then
-            echo "| $REPO | (scanned $runs_scanned runs) | - | 🔍 | 🔍 | No NPU runner jobs found in last $runs_scanned runs |"
+            echo "| $REPO | (scanned $runs_scanned runs) | - | 🔍 | 🔍 | 🔍 | 🔍 | No NPU runner jobs found in last $runs_scanned runs |"
             STAT_NO_NPU=$((STAT_NO_NPU + 1))
         else
-            echo "| $REPO | - | - | ⚠️ | ⚠️ | No completed runs / no access |"
+            echo "| $REPO | - | - | ⚠️ | ⚠️ | ⚠️ | ⚠️ | No completed runs / no access |"
             STAT_ERROR=$((STAT_ERROR + 1))
         fi
         continue
@@ -206,7 +213,7 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
 
         # Pre-check: skip jobs with no package installation activity at all
         # (e.g. docs-check, lint-only jobs that use pre-built images)
-        if ! grep -qiE "pip install|apt-get install|apt install|uv install|uv pip|dnf install|yum install|rustup toolchain|cargo install" "$log_file" 2>/dev/null; then
+        if ! grep -qiE "pip install|apt-get install|apt install|uv install|uv pip|dnf install|yum install|rustup toolchain|cargo install|ccache|cmake" "$log_file" 2>/dev/null; then
             rm -f "$log_file"
             continue
         fi
@@ -313,6 +320,75 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
             fi
         fi
 
+        # ---------- Search for CCache evidence (正面 + 反面) ----------
+        ev_ccache=""
+        counter_evidence_ccache=""
+
+        # 最强证据：ccache --print-stats 或 --show-stats 输出，说明本次构建实际使用了 ccache
+        grep_line=$(grep -m1 -iE "cache hit|cache miss|Cache hit|Cache miss|cache_hit|cache_miss|cachehit|cachemiss" "$log_file" 2>/dev/null || true)
+        if [ -n "$grep_line" ]; then
+            repo_ccache=true
+            ev_ccache="ccache统计(运行时): ${grep_line:0:200}"
+        fi
+
+        # 次强证据：TRITON_BUILD_WITH_CCACHE 或 CMAKE_C_COMPILER_LAUNCHER=ccache 出现在日志里
+        if [ "$repo_ccache" = false ]; then
+            grep_line=$(grep -m1 -iE "TRITON_BUILD_WITH_CCACHE|CMAKE_C_COMPILER_LAUNCHER.*ccache|CMAKE_CXX_COMPILER_LAUNCHER.*ccache|CC=ccache|CXX=ccache" "$log_file" 2>/dev/null || true)
+            if [ -n "$grep_line" ]; then
+                repo_ccache=true
+                ev_ccache="ccache-cmake(配置): ${grep_line:0:200}"
+            fi
+        fi
+
+        # 弱证据：CCACHE_* 环境变量或 ccache --zero-stats 出现（说明 workflow 配置了 ccache）
+        if [ "$repo_ccache" = false ]; then
+            grep_line=$(grep -m1 -iE "CCACHE_COMPRESS|CCACHE_DIR|ccache --zero-stats|ccache -z" "$log_file" 2>/dev/null || true)
+            if [ -n "$grep_line" ]; then
+                repo_ccache=true
+                ev_ccache="ccache-env(配置): ${grep_line:0:200}"
+            fi
+        fi
+
+        # 宽泛匹配：日志中出现 ccache 字样（排除注释和纯路径行）
+        if [ "$repo_ccache" = false ]; then
+            grep_line=$(grep -m1 -iE "(^|[^a-z])ccache([^a-z]|$)" "$log_file" 2>/dev/null \
+                | grep -viE "^\s*#|/usr/share/doc" || true)
+            if [ -n "$grep_line" ]; then
+                repo_ccache=true
+                ev_ccache="ccache-broad: ${grep_line:0:200}"
+            fi
+        fi
+
+        # 反面证据：ccache 不适用，有没有用只能从正面证据判断
+
+        # ---------- Search for uv evidence ----------
+        ev_uv=""
+
+        # 最强证据：uv 实际执行安装命令
+        grep_line=$(grep -m1 -iE "^\s*uv (pip |sync|install|add|run pip)" "$log_file" 2>/dev/null || true)
+        if [ -n "$grep_line" ]; then
+            repo_uv=true
+            ev_uv="uv-cmd(运行时): ${grep_line:0:200}"
+        fi
+
+        # 次强证据：uv pip install / uv sync 出现在日志（非行首，可能是 shell 展开后的输出）
+        if [ "$repo_uv" = false ]; then
+            grep_line=$(grep -m1 -iE "uv pip install|uv sync|uv install|Resolved .* packages|Prepared .* packages|Installed .* packages" "$log_file" 2>/dev/null || true)
+            if [ -n "$grep_line" ]; then
+                repo_uv=true
+                ev_uv="uv-output(运行时): ${grep_line:0:200}"
+            fi
+        fi
+
+        # 弱证据：UV_* 环境变量或 uv 工具安装步骤出现
+        if [ "$repo_uv" = false ]; then
+            grep_line=$(grep -m1 -iE "UV_INDEX_URL|UV_DEFAULT_INDEX|UV_CACHE_DIR|pip install uv|pipx install uv|curl.*uv.*install|astral-sh/uv" "$log_file" 2>/dev/null || true)
+            if [ -n "$grep_line" ]; then
+                repo_uv=true
+                ev_uv="uv-setup(配置): ${grep_line:0:200}"
+            fi
+        fi
+
         rm -f "$log_file"
 
         # Got a usable log — record which job it came from
@@ -332,7 +408,7 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
         first_job_id=$(echo "$first_candidate" | cut -d'|' -f4)
         first_runner=$(echo "$first_candidate" | cut -d'|' -f6)
         first_url="https://github.com/${REPO}/actions/runs/${first_run_id}/job/${first_job_id}"
-        echo "| $REPO | (NPU jobs found, logs expired) | $first_runner | ⚠️ | ⚠️ | NPU runner jobs found but all logs expired (>90 days) — [查看]($first_url) |"
+        echo "| $REPO | (NPU jobs found, logs expired) | $first_runner | ⚠️ | ⚠️ | ⚠️ | ⚠️ | NPU runner jobs found but all logs expired (>90 days) — [查看]($first_url) |"
         STAT_ERROR=$((STAT_ERROR + 1))
         continue
     fi
@@ -369,11 +445,29 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
         apt_detail="无证据(日志中未出现 apt Get/Hit 相关输出)"
     fi
 
-    evidence="${pypi_detail}; ${apt_detail}"
+    if [ "$repo_ccache" = true ]; then
+        ccache_mark="✅"
+        ccache_detail="${ev_ccache}"
+        STAT_CCACHE=$((STAT_CCACHE + 1))
+    else
+        ccache_mark="⚙️"
+        ccache_detail="无证据(日志中未出现 ccache 相关输出)"
+    fi
+
+    if [ "$repo_uv" = true ]; then
+        uv_mark="✅"
+        uv_detail="${ev_uv}"
+        STAT_UV=$((STAT_UV + 1))
+    else
+        uv_mark="⚙️"
+        uv_detail="无证据(日志中未出现 uv 相关输出)"
+    fi
+
+    evidence="${pypi_detail}; ${apt_detail}; ${ccache_detail}; ${uv_detail}"
     evidence="${evidence# ; }"
     evidence="${evidence% ; }"
 
-    echo "| $REPO | $repo_run | $repo_runner | $pypi_mark | $apt_mark | ${evidence:0:400} $job_link |"
+    echo "| $REPO | $repo_run | $repo_runner | $pypi_mark | $apt_mark | $ccache_mark | $uv_mark | ${evidence:0:400} $job_link |"
 
     rm -f "$LOG_DIR/${REPO//\//_}"*.log
 
@@ -388,6 +482,8 @@ echo ""
 echo "- Total repos checked: **$TOTAL**"
 echo "- PyPI cache hit: **$STAT_PYPI** / $TOTAL"
 echo "- APT cache hit: **$STAT_APT** / $TOTAL"
+echo "- CCache hit: **$STAT_CCACHE** / $TOTAL"
+echo "- uv hit: **$STAT_UV** / $TOTAL"
 echo "- NPU job found but no cache (❌): **$STAT_NO_CACHE** — need cache config"
 echo "- No NPU runner jobs found (🔍): **$STAT_NO_NPU** — repos don't use our NPU runners"
 echo "- Logs expired / unavailable (⚠️): **$STAT_ERROR**"

--- a/scripts/ci-audit/repos.txt
+++ b/scripts/ci-audit/repos.txt
@@ -1,14 +1,14 @@
-# org/repo|workflow-file.yml|pypi_default|apt_default
+# org/repo|workflow-file.yml|pypi_default|apt_default|ccache_default|uv_default
 # 默认值仅在审计无法确认时使用（⚙️/🔍/⚠️）
 # 审计确认的 ✅ 或 ❌ 优先级高于默认值
-sgl-project/sglang|pr-test-npu.yml||
-vllm-project/vllm-ascend|pr_test_full.yaml|✅|✅
-vllm-project/vllm-omni||||
-Ascend/Ascend-CI||||
-pytorch-fdn/accelerator-integration-wg||||
-sgl-project/sgl-kernel-npu||✅|✅
-volcengine/verl|e2e_ascend.yml|✅|✅
-hiyouga/LLaMA-Factory|tests_npu.yml||
-modelscope/ms-swift|citest_npu.yaml||
-tile-ai/tilelang-ascend|ci_npuir.yml||
-triton-lang/triton-ascend||||
+sgl-project/sglang|pr-test-npu.yml||||
+vllm-project/vllm-ascend|pr_test_full.yaml|✅|✅||
+vllm-project/vllm-omni||||||
+Ascend/Ascend-CI||||||
+pytorch-fdn/accelerator-integration-wg||||||
+sgl-project/sgl-kernel-npu||✅|✅||
+volcengine/verl|e2e_ascend.yml|✅|✅||
+hiyouga/LLaMA-Factory|tests_npu.yml||||
+modelscope/ms-swift|citest_npu.yaml||||
+tile-ai/tilelang-ascend|ci_npuir.yml||||
+triton-lang/triton-ascend|||✅||

--- a/scripts/ci-audit/update_repo_md.py
+++ b/scripts/ci-audit/update_repo_md.py
@@ -33,7 +33,7 @@ INTRANET_PATTERNS = [
 INTRANET_RE = re.compile('|'.join(INTRANET_PATTERNS))
 
 # ---------- 读取 repos.txt 默认值 ----------
-defaults = {}  # repo -> (pypi_default, apt_default)
+defaults = {}  # repo -> (pypi_default, apt_default, ccache_default)
 workflow_map = {}  # repo -> workflow_file (unused here, for reference)
 
 with open(REPOS_FILE) as f:
@@ -42,16 +42,18 @@ with open(REPOS_FILE) as f:
         if not line or line.startswith("#"):
             continue
         parts = line.split("|")
-        repo = parts[0].strip()
-        wf   = parts[1].strip() if len(parts) > 1 else ""
-        pypi = parts[2].strip() if len(parts) > 2 else ""
-        apt  = parts[3].strip() if len(parts) > 3 else ""
+        repo    = parts[0].strip()
+        wf      = parts[1].strip() if len(parts) > 1 else ""
+        pypi    = parts[2].strip() if len(parts) > 2 else ""
+        apt     = parts[3].strip() if len(parts) > 3 else ""
+        ccache  = parts[4].strip() if len(parts) > 4 else ""
+        uv      = parts[5].strip() if len(parts) > 5 else ""
         workflow_map[repo] = wf
-        defaults[repo] = (pypi or None, apt or None)
+        defaults[repo] = (pypi or None, apt or None, ccache or None, uv or None)
 
 # ---------- 解析审计结果 ----------
-# 格式：| repo | run | runner | PyPI 缓存 | APT 缓存 | 证据 |
-audit_results = {}  # repo -> (pypi, apt)
+# 格式：| repo | run | runner | PyPI 缓存 | APT 缓存 | CCache | uv | 证据 |
+audit_results = {}  # repo -> (pypi, apt, ccache, uv)
 
 UNDECIDED = {"⚙️", "⚠️", "🔍"}
 
@@ -60,11 +62,13 @@ with open(AUDIT_FILE) as f:
         if not line.startswith("| "):
             continue
         cols = [c.strip() for c in line.split("|")]
-        if len(cols) < 7:
+        if len(cols) < 9:
             continue
-        repo_col = cols[1]
-        pypi_col = cols[4]
-        apt_col  = cols[5]
+        repo_col   = cols[1]
+        pypi_col   = cols[4]
+        apt_col    = cols[5]
+        ccache_col = cols[6]
+        uv_col     = cols[7]
 
         # 提取 org/repo（去掉 markdown 链接格式）
         m = re.search(r'([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)', repo_col)
@@ -72,7 +76,7 @@ with open(AUDIT_FILE) as f:
             continue
         repo = m.group(1)
 
-        evidence_col = cols[6] if len(cols) > 6 else ""
+        evidence_col = cols[8] if len(cols) > 8 else ""
 
         def resolve(val, evidence, default):
             if val == "✅":
@@ -85,9 +89,17 @@ with open(AUDIT_FILE) as f:
             # ⚙️/⚠️/🔍 不确定，用默认值
             return default  # None = 不知道
 
-        pypi = resolve(pypi_col, evidence_col, defaults.get(repo, (None, None))[0])
-        apt  = resolve(apt_col,  evidence_col, defaults.get(repo, (None, None))[1])
-        audit_results[repo] = (pypi, apt)
+        def resolve_simple(val, default):
+            # 只有正面证据，⚙️/⚠️/🔍 均视为无数据
+            if val == "✅":
+                return "✅"
+            return default  # None = 不知道
+
+        pypi   = resolve(pypi_col, evidence_col, defaults.get(repo, (None, None, None, None))[0])
+        apt    = resolve(apt_col,  evidence_col, defaults.get(repo, (None, None, None, None))[1])
+        ccache = resolve_simple(ccache_col, defaults.get(repo, (None, None, None, None))[2])
+        uv     = resolve_simple(uv_col,     defaults.get(repo, (None, None, None, None))[3])
+        audit_results[repo] = (pypi, apt, ccache, uv)
 
 # ---------- 读取 Repo.md，提取仓库顺序 ----------
 with open(REPO_MD) as f:
@@ -110,19 +122,19 @@ def fmt(val):
     return val
 
 rows = []
-rows.append("| Repository | PyPI Cache | APT Cache | Last Checked |")
-rows.append("| :--- | :---: | :---: | :--- |")
+rows.append("| Repository | PyPI Cache | APT Cache | CCache | uv | Last Checked |")
+rows.append("| :--- | :---: | :---: | :---: | :---: | :--- |")
 
 for repo in repos_ordered:
-    pypi, apt = audit_results.get(repo, (None, None))
-    # 如果审计没拿到值，用默认值
-    if pypi is None:
-        pypi = defaults.get(repo, (None, None))[0]
-    if apt is None:
-        apt = defaults.get(repo, (None, None))[1]
+    pypi, apt, ccache, uv = audit_results.get(repo, (None, None, None, None))
+    defs = defaults.get(repo, (None, None, None, None))
+    if pypi   is None: pypi   = defs[0]
+    if apt    is None: apt    = defs[1]
+    if ccache is None: ccache = defs[2]
+    if uv     is None: uv     = defs[3]
     rows.append(
         f"| [{repo}](https://github.com/{repo}) "
-        f"| {fmt(pypi)} | {fmt(apt)} | {TODAY} |"
+        f"| {fmt(pypi)} | {fmt(apt)} | {fmt(ccache)} | {fmt(uv)} | {TODAY} |"
     )
 
 new_table = "\n".join([TABLE_START] + rows + [TABLE_END])
@@ -133,7 +145,7 @@ if RUN_URL:
 else:
     footer = "> 缓存状态每日自动审计更新。\n> ✅ = 已确认接入 · ❌ = 已确认未接入 · - = 暂无数据"
 
-FOOTER_RE = re.compile(r'^> (Cache audit runs daily|缓存状态每日自动审计更新)\..*$', re.MULTILINE)
+FOOTER_RE = re.compile(r'^> (Cache audit runs daily|缓存状态每日自动审计更新)[.。].*$', re.MULTILINE)
 
 # ---------- 替换 Repo.md 中的表格区域 ----------
 if TABLE_START in content and TABLE_END in content:


### PR DESCRIPTION
## Summary

- **新增 CCache 列**：检测仓库是否在 CI 中使用 ccache 加速 C++ 编译。检测层次：ccache 统计输出（运行时）→ CMake launcher 环境变量 → CCACHE_* 变量（配置层）。只有正面证据，无反面证据。
- **新增 uv 列**：检测仓库是否使用 uv 安装 Python 包。检测层次：uv 命令运行时输出 → uv install/sync 输出关键词 → UV_* 环境变量/安装步骤（配置层）。
- **修复 footer 正则 bug**：`\.` 不匹配中文句号 `。`，导致 `update_repo_md.py` 每次跑完都无法替换中文 footer，旧的 run URL 一直停留。改为 `[.。]` 后每次 CI 运行将正确写入最新链接。
- `repos.txt` 新增第 5/6 列（`ccache_default`/`uv_default`），`triton-lang/triton-ascend` 标记 `ccache_default=✅`。
- `docs/Repo.md` 表格加两列，移除硬编码旧 run URL，下次审计运行后自动覆盖。

## Test plan

- [ ] 语法检查：`python3 -m py_compile scripts/ci-audit/update_repo_md.py` 和 `bash -n scripts/ci-audit/check_cache_from_logs.sh` 均通过
- [ ] 触发一次 CI Cache Audit workflow，确认 Repo.md 表格正确更新 CCache/uv 列及 footer 链接