### PR TITLE
docs: expand README with positioning, links, and app URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-This repo contains the user manual of self hosted runners intergeted Ascend device.
+# Ascend GitHub Action Runners
+
+Self-hosted [GitHub Actions](https://docs.github.com/en/actions) and [Buildkite](https://buildkite.com) runners running on **Ascend NPU** (Huawei AI accelerators), offered as a managed CI service for open-source AI/ML projects. Jobs run on real Ascend chips (Atlas 300I DUO / 800 A2 / A3) with the CANN software stack, so you can build and test NPU workloads without owning the hardware — see [which projects already use it](https://ascend-gha-runners.github.io/docs/Repo/).
+
+> Access is **not self-serve**: install the [`ascend-runner-mgmt`](https://github.com/apps/ascend-runner-mgmt) GitHub App (or send a PAT) and contact `ascendinfra@huawei.com` to activate. See the integration guides below.
+
+## Documentation
+
+Rendered site: **https://ascend-gha-runners.github.io/docs/**
+
+### Integration guides
+
+| CI | English | 中文 |
+|---|---|---|
+| GitHub Actions | [user-manual-gha-en.md](docs/user-manual-gha-en.md) | [user-manual-gha-zh.md](docs/user-manual-gha-zh.md) |
+| Buildkite | [user-manual-buildkite-en.md](docs/user-manual-buildkite-en.md) | [user-manual-buildkite-zh.md](docs/user-manual-buildkite-zh.md) |
+
+### Reference
+
+- [Platform features](docs/feature.md) — PyPI/Apt cache, Git smart proxy, S3 cache, sccache
+- [Runner advanced features](docs/runner-features-en.md) · [中文](docs/runner-features-zh.md)
+- [Integrated repositories](docs/Repo.md)
+- [CI infrastructure deployment (contributor)](docs/ci-infrastructure-deployment-zh.md)
+
+## Feedback
+
+Open a [discussion](https://github.com/ascend-gha-runners/docs/discussions) or an [issue](https://github.com/ascend-gha-runners/docs/issues).


### PR DESCRIPTION
## What

The README was a single typo'd sentence ("intergeted") with no orientation. This expands it — still concise — so a newcomer landing on the repo understands what this is and where to go.

## Changes

- **Positioning**: one-line what-it-is — self-hosted GitHub Actions / Buildkite runners on Ascend NPU, a managed CI service for open-source AI/ML projects; jobs run on real Ascend chips (Atlas 300I DUO / 800 A2 / A3) with CANN.
- **Non-self-serve note**: install the `ascend-runner-mgmt` GitHub App (now a clickable link → https://github.com/apps/ascend-runner-mgmt) or send a PAT, and contact `ascendinfra@huawei.com` to activate.
- **Docs site URL** + EN/ZH integration-guide table (GHA, Buildkite).
- **Reference links**, including the currently-orphaned `runner-features` and `ci-infrastructure-deployment` pages (not in `mkdocs.yml` nav — at least reachable from README now).
- **No hardcoded project list**: replaced `vLLM, SGLang, vERL, …` with a link to the Repo page (its integrated-repos table is auto-audited daily) so the README cannot go stale.
- Unified feedback entry to discussions/issues.

## Out of scope (intentionally not done)

- Writing a full "What is Ascend GHA Runner" overview page.
- Adding the 3 orphan pages into `mkdocs.yml` nav.
- EN version of `ci-infrastructure-deployment-zh.md`.
- Fixing the divergent feedback channels across guides.

Happy to follow up on any of these if wanted.