### PR TITLE
fix(docs): repair dead links

### DIFF
--- a/docs/user-manual-buildkite-en.md
+++ b/docs/user-manual-buildkite-en.md
@@ -337,8 +337,6 @@ How to verify this step is complete:
 
 ### Step 6: Validate Integration
 
-<!-- TODO: Add image: ![Validate Integration](assets/user-manual-en/buildkite-verification.png) -->
-
 Complete validation flow:
 
 1. **Confirm Agent is connected**
@@ -420,8 +418,8 @@ On the Buildkite website → navigate to a specific Build → click any Step →
 
 If you encounter any issues during integration, please report them through:
 
-- **Submit an Issue**: [https://github.com/opensourceways/backlog](https://github.com/opensourceways/backlog)
-- When submitting an Issue, please provide:
+- **Open a discussion**: [https://github.com/ascend-gha-runners/docs/discussions](https://github.com/ascend-gha-runners/docs/discussions)
+- When submitting, please provide:
   - Project name and Git repository URL
   - Issue description and error log screenshots
   - Completed steps and where you are stuck

--- a/docs/user-manual-buildkite-zh.md
+++ b/docs/user-manual-buildkite-zh.md
@@ -416,8 +416,8 @@ steps:
 
 如果在接入过程中遇到任何问题，请通过以下方式反馈：
 
-- **提交 Issue**：[https://github.com/opensourceways/backlog](https://github.com/opensourceways/backlog)
-- 提交 Issue 时，请提供以下信息：
+- **发起讨论**：[https://github.com/ascend-gha-runners/docs/discussions](https://github.com/ascend-gha-runners/docs/discussions)
+- 提交时，请提供以下信息：
   - 项目名称和 Git 仓库地址
   - 问题描述和错误日志截图
   - 已完成的步骤和卡住的环节


### PR DESCRIPTION
## What

Fixes all dead links found by scanning every link in `README.md` + `docs/*.md` (internal paths, anchors, and external URLs probed with curl).

## Fixes

| Link (was) | Status | Now |
|---|---|---|
| `github.com/opensourceways/backlog` | 404 (repo does not exist) | `ascend-gha-runners/docs/discussions` (200) |
| `vllm-ascend/.../workflows/_e2e_test.yaml` | 404 (file renamed away) | `vllm-ascend/tree/main/.github/workflows` (200, directory = stable across renames) |
| `assets/user-manual-en/buildkite-verification.png` | missing image in a `<!-- TODO -->` comment | TODO comment removed |

**Files touched:** `user-manual-buildkite-en.md`, `user-manual-buildkite-zh.md`, `runner-features-en.md`, `runner-features-zh.md`.

Buildkite feedback wording changed `Submit an Issue` → `Open a discussion` to match the new (discussions) link and the GHA guides — the old text pointed at an Issue tracker that no longer exists.

## Note on runner-features-en/zh

These two files were **untracked** (never committed, also not in `mkdocs.yml` nav). They are added here in full so their dead-link fix actually ships. Diff is large because the files are new, not because of heavy edits — the only real change in them is the one workflow link.

**Still not done (follow-up):** `runner-features-en/zh` and `ci-infrastructure-deployment-zh.md` are still absent from `mkdocs.yml` nav, so they remain unreachable from the site. Happy to add them in a separate PR.

## Verification

Re-scanned after the fix: 0 internal dead links, 0 dead anchors, and both replacement URLs return 200.