### PR TITLE
feat: add linux-aarch64-a5 (Ascend950DT) runner entries

### DIFF
--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -17,6 +17,7 @@
 | Atlas 800T A2 376T  | arm64  | 910B2 | linux-aarch64-a2b2-x  |
 | Atlas 800T A2 313T  | arm64  | 910B3 | linux-aarch64-a2b3-x  |
 | Atlas 800I A2 560T  | arm64  | 910B4 | linux-aarch64-a2b4-x  |
+| Atlas A5 (Ascend950DT) | arm64  | NA    | linux-aarch64-a5-x    |
 
 ### Runner pod 资源配额
 
@@ -58,6 +59,10 @@
 |linux-aarch64-a2b4-2|2|46|128Gi|
 |linux-aarch64-a2b4-4|4|92|256Gi|
 |linux-aarch64-a2b4-8|8|184|512Gi|
+|linux-aarch64-a5-0|0|16|32Gi|
+|linux-aarch64-a5-2|2|82|384Gi|
+|linux-aarch64-a5-4|4|164|768Gi|
+|linux-aarch64-a5-8|8|360|1350Gi|
 
 ### Runner pod 命名规范
 


### PR DESCRIPTION
## 描述

添加上海集群 Ascend950DT (A5) runner 的类型定义和资源配额。

### 新增类型
| 类型 | 架构 | 命名 |
|------|------|------|
| Atlas A5 (Ascend950DT) | arm64 | linux-aarch64-a5-x |

### 资源配额
| Runner | NPU | CPU | 内存 |
|--------|-----|-----|------|
| linux-aarch64-a5-0 | 0 | 16 | 32Gi |
| linux-aarch64-a5-2 | 2 | 82 | 384Gi |
| linux-aarch64-a5-4 | 4 | 164 | 768Gi |
| linux-aarch64-a5-8 | 8 | 360 | 1350Gi |

## 相关 Issue


## 变更类型
- [ ] Bug 修复
- [x] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他