### PR TITLE
docs: add vllm-ascend 800i-2/4/8 aiframe/mind precision-test runner names

### DIFF
--- a/docs/user-manual-gha-zh.md
+++ b/docs/user-manual-gha-zh.md
@@ -40,6 +40,12 @@
 |linux-aarch64-a3-800i-4|4|78|128Gi|
 |linux-aarch64-a3-800i-8|8|156|256Gi|
 |linux-aarch64-a3-800i-16|16|312|512Gi|
+|linux-aarch64-a3-800i-2-aiframe|2|32|128Gi|
+|linux-aarch64-a3-800i-4-aiframe|4|64|256Gi|
+|linux-aarch64-a3-800i-8-aiframe|8|128|512Gi|
+|linux-aarch64-a3-800i-2-mind|2|32|128Gi|
+|linux-aarch64-a3-800i-4-mind|4|64|256Gi|
+|linux-aarch64-a3-800i-8-mind|8|128|512Gi|
 |linux-aarch64-a3-800t-0|0|4|8Gi|
 |linux-aarch64-a3-800t-2|2|39|64Gi|
 |linux-aarch64-a3-800t-4|4|78|128Gi|


### PR DESCRIPTION
为 vllm-project/vllm-ascend 在 aiframework、mind-third-ci 两个集群新增的精度测试 runner 补充 runner-name 表项，配合 ascend-ci-deployment 侧 PR https://github.com/opensourceways/ascend-ci-deployment/pull/1442 使用（该 PR 的 check-projects-coverage.py [RC] 检查依赖本表）。

新增：
- linux-aarch64-a3-800i-2-aiframe / -4-aiframe / -8-aiframe
- linux-aarch64-a3-800i-2-mind / -4-mind / -8-mind

CPU/内存数值对齐现有 linux-aarch64-a3-800i-2/4/8 一档。